### PR TITLE
Make cycle finder return edges

### DIFF
--- a/Sources/SwiftGraph/Cycle.swift
+++ b/Sources/SwiftGraph/Cycle.swift
@@ -76,7 +76,7 @@ public extension Graph {
     ///
     /// - parameter upToLength: Does the caller only want to detect cycles up to a certain length?
     /// - returns: a list of lists of edges in cycles
-    public func detectCyclesOfEdges(upToLength maxK: Int = Int.max) -> [[Edge]] {
+    public func detectCyclesAsEdges(upToLength maxK: Int = Int.max) -> [[Edge]] {
 
         var cycles = [[Edge]]() // store of all found cycles
         var openPaths: [Path] = (0..<vertices.count).map(Path.init(start:)) // initial open paths start at a vertext, and are empty

--- a/Sources/SwiftGraph/Cycle.swift
+++ b/Sources/SwiftGraph/Cycle.swift
@@ -70,9 +70,7 @@ public extension Graph {
         var tail: Int {
             return path.last?.v ?? start
         }
-
     }
-
 
     /// Find all of the cycles in a `Graph`, expressed as edges.
     ///

--- a/Sources/SwiftGraph/Cycle.swift
+++ b/Sources/SwiftGraph/Cycle.swift
@@ -49,29 +49,6 @@ public extension Graph {
         return cycles
     }
 
-    struct Path {
-        var start: Int
-        var path: [Edge] = []
-
-        init(start: Int) {
-            self.start = start
-        }
-
-        func byAdding(_ edge: Edge) -> Path {
-            var mutable = self
-            mutable.path.append(edge)
-            return mutable
-        }
-
-        var head: Int {
-            return start
-        }
-
-        var tail: Int {
-            return path.last?.v ?? start
-        }
-    }
-
     /// Find all of the cycles in a `Graph`, expressed as edges.
     ///
     /// - parameter upToLength: Does the caller only want to detect cycles up to a certain length?
@@ -98,4 +75,31 @@ public extension Graph {
 
         return cycles
     }
+}
+
+private extension Graph {
+
+    struct Path {
+        var start: Int
+        var path: [Edge] = []
+
+        init(start: Int) {
+            self.start = start
+        }
+
+        func byAdding(_ edge: Edge) -> Path {
+            var mutable = self
+            mutable.path.append(edge)
+            return mutable
+        }
+
+        var head: Int {
+            return start
+        }
+
+        var tail: Int {
+            return path.last?.v ?? start
+        }
+    }
+
 }

--- a/Sources/SwiftGraph/Cycle.swift
+++ b/Sources/SwiftGraph/Cycle.swift
@@ -75,7 +75,7 @@ public extension Graph {
     /// Find all of the cycles in a `Graph`, expressed as edges.
     ///
     /// - parameter upToLength: Does the caller only want to detect cycles up to a certain length?
-    /// - returns: a list of lists of vertices in cycles
+    /// - returns: a list of lists of edges in cycles
     public func detectCyclesOfEdges(upToLength maxK: Int = Int.max) -> [[Edge]] {
 
         var cycles = [[Edge]]() // store of all found cycles

--- a/Sources/SwiftGraph/Cycle.swift
+++ b/Sources/SwiftGraph/Cycle.swift
@@ -24,7 +24,7 @@ public extension Graph {
     // In Telecommunications, 2006. AICT-ICIW'06. International Conference on Internet and
     // Web Applications and Services/Advanced International Conference on, pp. 57-57. IEEE, 2006.
     
-    /// Find all of the cycles in a `Graph`
+    /// Find all of the cycles in a `Graph`, expressed as verticies.
     ///
     /// - parameter upToLength: Does the caller only want to detect cycles up to a certain length?
     /// - returns: a list of lists of vertices in cycles
@@ -47,6 +47,60 @@ public extension Graph {
             }
         }
         
+        return cycles
+    }
+
+    struct Path {
+        var start: Int
+        var path: [Edge] = []
+
+        init(start: Int) {
+            self.start = start
+        }
+
+        func byAdding(_ edge: Edge) -> Path {
+            var mutable = self
+            mutable.path.append(edge)
+            return mutable
+        }
+
+        var head: Int {
+            return start
+        }
+
+        var tail: Int {
+            return path.last?.v ?? start
+        }
+
+    }
+
+
+    /// Find all of the cycles in a `Graph`, expressed as edges.
+    ///
+    /// - parameter upToLength: Does the caller only want to detect cycles up to a certain length?
+    /// - returns: a list of lists of vertices in cycles
+    public func detectCyclesOfEdges(upToLength maxK: Int = Int.max) -> [[Edge]] {
+
+        var cycles = [[Edge]]() // store of all found cycles
+        var openPaths: [Path] = (0..<vertices.count).map(Path.init(start:)) // initial open paths are single vertex lists
+
+        while openPaths.count > 0 {
+            let openPath = openPaths.removeFirst() // queue pop()
+            //print(openPath)
+            if openPath.path.count > maxK { return cycles } // do we want to stop at a certain length k
+            let tail = openPath.tail
+            let head = openPath.head
+            let neighborEdges = edgesForIndex(tail)
+            for neighborEdge in neighborEdges {
+                if neighborEdge.v == head {
+                    cycles.append(openPath.path + [neighborEdge]) // found a cycle
+//                    else if !openPath.contains(neighbor) && indexOfVertex(neighbor)! > indexOfVertex(head)!
+                } else if !openPath.path.contains(where: { $0.u == neighborEdge.v || $0.v == neighborEdge.v }) && neighborEdge.v > head {
+                    openPaths.append(openPath.byAdding(neighborEdge)) // another open path to explore
+                }
+            }
+        }
+
         return cycles
     }
 }

--- a/Sources/SwiftGraph/Cycle.swift
+++ b/Sources/SwiftGraph/Cycle.swift
@@ -24,7 +24,7 @@ public extension Graph {
     // In Telecommunications, 2006. AICT-ICIW'06. International Conference on Internet and
     // Web Applications and Services/Advanced International Conference on, pp. 57-57. IEEE, 2006.
     
-    /// Find all of the cycles in a `Graph`, expressed as verticies.
+    /// Find all of the cycles in a `Graph`, expressed as vertices.
     ///
     /// - parameter upToLength: Does the caller only want to detect cycles up to a certain length?
     /// - returns: a list of lists of vertices in cycles

--- a/Sources/SwiftGraph/Cycle.swift
+++ b/Sources/SwiftGraph/Cycle.swift
@@ -34,7 +34,6 @@ public extension Graph {
         
         while openPaths.count > 0 {
             let openPath = openPaths.removeFirst() // queue pop()
-            //print(openPath)
             if openPath.count > maxK { return cycles } // do we want to stop at a certain length k
             if let tail = openPath.last, let head = openPath.first, let neighbors = neighborsForVertex(tail) {
                 for neighbor in neighbors {
@@ -82,11 +81,10 @@ public extension Graph {
     public func detectCyclesOfEdges(upToLength maxK: Int = Int.max) -> [[Edge]] {
 
         var cycles = [[Edge]]() // store of all found cycles
-        var openPaths: [Path] = (0..<vertices.count).map(Path.init(start:)) // initial open paths are single vertex lists
+        var openPaths: [Path] = (0..<vertices.count).map(Path.init(start:)) // initial open paths start at a vertext, and are empty
 
         while openPaths.count > 0 {
             let openPath = openPaths.removeFirst() // queue pop()
-            //print(openPath)
             if openPath.path.count > maxK { return cycles } // do we want to stop at a certain length k
             let tail = openPath.tail
             let head = openPath.head
@@ -94,7 +92,6 @@ public extension Graph {
             for neighborEdge in neighborEdges {
                 if neighborEdge.v == head {
                     cycles.append(openPath.path + [neighborEdge]) // found a cycle
-//                    else if !openPath.contains(neighbor) && indexOfVertex(neighbor)! > indexOfVertex(head)!
                 } else if !openPath.path.contains(where: { $0.u == neighborEdge.v || $0.v == neighborEdge.v }) && neighborEdge.v > head {
                     openPaths.append(openPath.byAdding(neighborEdge)) // another open path to explore
                 }

--- a/Tests/SwiftGraphTests/CycleTests.swift
+++ b/Tests/SwiftGraphTests/CycleTests.swift
@@ -62,7 +62,7 @@ class CycleTests: XCTestCase {
         ]
 
         let detectedVertexCycles = simpleGraph.detectCycles()
-        let detectedEdgeCycles = simpleGraph.detectCyclesOfEdges()
+        let detectedEdgeCycles = simpleGraph.detectCyclesAsEdges()
 
         XCTAssertEqual(detectedVertexCycles.count, solutionVertexCycles.count)
         XCTAssertTrue(detectedVertexCycles[0].elementsEqual(solutionVertexCycles[1]))

--- a/Tests/SwiftGraphTests/CycleTests.swift
+++ b/Tests/SwiftGraphTests/CycleTests.swift
@@ -53,11 +53,34 @@ class CycleTests: XCTestCase {
         simpleGraph.addEdge(from: "D", to: "C", directed: true)
         simpleGraph.addEdge(from: "C", to: "A", directed: true)
         simpleGraph.addEdge(from: "C", to: "B", directed: true)
-        let solutionCycles = [["A", "B", "D", "C", "A"], ["A", "D", "C", "A"], ["B", "D", "C", "B"]]
-        let detectedCycles = simpleGraph.detectCycles()
-        XCTAssertEqual(detectedCycles.count, solutionCycles.count)
-        for cycle in solutionCycles {
-            XCTAssertNotNil(detectedCycles.contains(where: { $0 == cycle }))
+
+        let solutionVertexCycles = [["A", "B", "D", "C", "A"], ["A", "D", "C", "A"], ["B", "D", "C", "B"]]
+        let solutionEdgeCycles: [[(Int, Int)]] = [
+            [(0, 1), (1, 3), (3, 2), (2, 0)],
+            [(0, 3), (3, 2), (2, 0)],
+            [(1, 3), (3, 2), (2, 1)],
+        ]
+
+        let detectedVertexCycles = simpleGraph.detectCycles()
+        let detectedEdgeCycles = simpleGraph.detectCyclesOfEdges()
+
+        XCTAssertEqual(detectedVertexCycles.count, solutionVertexCycles.count)
+        XCTAssertTrue(detectedVertexCycles[0].elementsEqual(solutionVertexCycles[1]))
+        XCTAssertTrue(detectedVertexCycles[1].elementsEqual(solutionVertexCycles[2]))
+        XCTAssertTrue(detectedVertexCycles[2].elementsEqual(solutionVertexCycles[0]))
+
+        print(detectedEdgeCycles)
+
+        XCTAssertEqual(detectedEdgeCycles.count, solutionEdgeCycles.count)
+        assertArraysOfTuplesEqual(detectedEdgeCycles[0].map { edge in (edge.u, edge.v) }, solutionEdgeCycles[1])
+        assertArraysOfTuplesEqual(detectedEdgeCycles[1].map { edge in (edge.u, edge.v) }, solutionEdgeCycles[2])
+        assertArraysOfTuplesEqual(detectedEdgeCycles[2].map { edge in (edge.u, edge.v) }, solutionEdgeCycles[0])
+    }
+
+    func assertArraysOfTuplesEqual(_ lhs: [(Int, Int)], _ rhs: [(Int, Int)], line: UInt = #line) {
+        let elementsEqual = lhs.elementsEqual(rhs) { (left, right) -> Bool in left.0 == right.0 && left.1 == right.1 }
+        if !elementsEqual {
+            XCTFail("Arrays not equal: \(lhs), \(rhs)", line: line)
         }
     }
     

--- a/Tests/SwiftGraphTests/CycleTests.swift
+++ b/Tests/SwiftGraphTests/CycleTests.swift
@@ -72,9 +72,9 @@ class CycleTests: XCTestCase {
         print(detectedEdgeCycles)
 
         XCTAssertEqual(detectedEdgeCycles.count, solutionEdgeCycles.count)
-        assertArraysOfTuplesEqual(detectedEdgeCycles[0].map { edge in (edge.u, edge.v) }, solutionEdgeCycles[1])
-        assertArraysOfTuplesEqual(detectedEdgeCycles[1].map { edge in (edge.u, edge.v) }, solutionEdgeCycles[2])
-        assertArraysOfTuplesEqual(detectedEdgeCycles[2].map { edge in (edge.u, edge.v) }, solutionEdgeCycles[0])
+        assertArraysOfTuplesEqual(detectedEdgeCycles[0].map { edge in edge.asTuple }, solutionEdgeCycles[1])
+        assertArraysOfTuplesEqual(detectedEdgeCycles[1].map { edge in edge.asTuple }, solutionEdgeCycles[2])
+        assertArraysOfTuplesEqual(detectedEdgeCycles[2].map { edge in edge.asTuple }, solutionEdgeCycles[0])
     }
 
     func assertArraysOfTuplesEqual(_ lhs: [(Int, Int)], _ rhs: [(Int, Int)], line: UInt = #line) {
@@ -88,4 +88,12 @@ class CycleTests: XCTestCase {
         ("testFullyConnected", testFullyConnected),
         ("testDetectCycles1", testDetectCycles1)
     ]
+}
+
+extension Edge {
+
+    var asTuple: (Int, Int) {
+        return (u, v)
+    }
+
 }


### PR DESCRIPTION
The functions are duplicated. I don't feel great about that, but I looked into having a shared function that can return cycles or edges, but it either has a bunch of branching or a bunch of time/storage overhead to go from edges to vertices. It seemed better to just leave them separate.