### PR TITLE
Add Equatable conformance to Graph and Edge

### DIFF
--- a/Sources/SwiftGraph/ArrayCompareElements.swift
+++ b/Sources/SwiftGraph/ArrayCompareElements.swift
@@ -1,0 +1,39 @@
+//
+//  ArrayCompareElements.swift
+//  SwiftGraph
+//
+//  Copyright (c) 2018 Ferran Pujol Camins
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+extension Array where Element: Equatable {
+
+    /// Check if two arrays of Equatable elements have the same elements ignoring order.
+    public func hasSameElements(_ other: Array<Element> ) -> Bool {
+        guard self.count == other.count else {
+            return false
+        }
+
+        var other = other
+
+        for element in self {
+            if let index = other.index(where:{ $0 == element }) {
+                other.remove(at:index)
+            } else {
+                return false
+            }
+        }
+
+        return other.isEmpty
+    }
+}

--- a/Sources/SwiftGraph/Edge.swift
+++ b/Sources/SwiftGraph/Edge.swift
@@ -25,4 +25,62 @@ public protocol Edge: CustomStringConvertible {
     var weighted: Bool {get}
     var directed: Bool {get}
     var reversed: Edge {get}
+
+    func isEqualTo(_ other: Edge) -> Bool
+    func asEquatable() -> AnyEquatableEdge
+}
+
+extension Edge {
+    public func asEquatable() -> AnyEquatableEdge {
+        return AnyEquatableEdge(self)
+    }
+}
+
+/// Type erasure over Edge subclasses that implements Equatable
+public struct AnyEquatableEdge: Edge, Equatable {
+    public init(_ edge: Edge) {
+        self.edge = edge
+    }
+    public init(_ anyEdge: AnyEquatableEdge) {
+        self.edge = anyEdge.edge
+    }
+
+    public var u: Int {
+        get {
+            return edge.u
+        }
+        set(newU) {
+            edge.u = newU
+        }
+    }
+    public var v: Int {
+        get {
+            return edge.v
+        }
+        set(newV) {
+            edge.v = newV
+        }
+    }
+    public var weighted: Bool { get { return edge.weighted } }
+    public var directed: Bool { get { return edge.directed } }
+    public var reversed: Edge { get { return edge.reversed } }
+
+    public func isEqualTo(_ other: Edge) -> Bool {
+        return edge.isEqualTo(other)
+    }
+
+    public func asEquatable() -> AnyEquatableEdge {
+        return self
+    }
+
+    public static func ==(lhs: AnyEquatableEdge, rhs: AnyEquatableEdge) -> Bool {
+        return lhs.edge.isEqualTo(rhs.edge)
+    }
+
+    //Implement Printable protocol
+    public var description: String {
+        return edge.description
+    }
+
+    private var edge: Edge
 }

--- a/Sources/SwiftGraph/Graph.swift
+++ b/Sources/SwiftGraph/Graph.swift
@@ -19,7 +19,7 @@
 /// The superclass for all graphs. Defined as a class instead of a protocol so that its subclasses can
 /// have some method implementations in common. You should generally use one of its two canonical subclasses,
 /// *UnweightedGraph* and *WeightedGraph*, because they offer more functionality and convenience.
-open class Graph<V: Equatable>: CustomStringConvertible, Sequence, Collection {
+open class Graph<V: Equatable>: CustomStringConvertible, Sequence, Collection, Equatable {
     var vertices: [V] = [V]()
     var edges: [[Edge]] = [[Edge]]() //adjacency lists
     
@@ -286,5 +286,32 @@ open class Graph<V: Equatable>: CustomStringConvertible, Sequence, Collection {
     /// - returns: The vertex at index.
     public subscript(i: Int) -> V {
         return vertexAtIndex(i)
+    }
+
+    /// This operator checks for equality of two Graphs with the same vertex type.
+    ///
+    /// We say to Graphs A and B with vertex type V are equal if:
+    /// * They have the same number of vertices and each vertex of A has an equal vertex on B,
+    ///   where equality is checked with the == operator of V.
+    /// * They have the same number of edges and each edge of A has an equal edge on B,
+    ///   where equality is checked with the == operator of Edge.
+    ///
+    /// The Edge implementations provided with this library implement value-semantics
+    /// equality. So, if V implements value-semantics equality, Graph
+    /// will also have value-semantics equality.
+    ///
+    /// Two isomorphic Graphs are not necessary equal by this operator.
+    /// An instance of Graph is always equal to itself, but two distinct instances
+    /// can be equal by this operator. You can use the === operator to check instance
+    /// identity.
+    ///
+    /// - returns: true if both Graphs are equal, false otherwise.
+    public static func == (lhs: Graph<V>, rhs: Graph<V>) -> Bool {
+
+        let equatableLhsEdges = lhs.edges.reduce([],+).map({ $0.asEquatable() })
+        let equatableRhsEdges = rhs.edges.reduce([],+).map({ $0.asEquatable() })
+
+        return lhs.vertices.hasSameElements(rhs.vertices)
+                && equatableLhsEdges.hasSameElements(equatableRhsEdges)
     }
 }

--- a/Sources/SwiftGraph/UnweightedEdge.swift
+++ b/Sources/SwiftGraph/UnweightedEdge.swift
@@ -31,6 +31,11 @@ open class UnweightedEdge: Edge, Equatable, CustomStringConvertible {
         self.v = v
         self.directed = directed
     }
+
+    public func isEqualTo(_ other: Edge) -> Bool {
+        guard let _other = other as? UnweightedEdge else { return false }
+        return self == _other
+    }
     
     //Implement Printable protocol
     public var description: String {

--- a/Sources/SwiftGraph/WeightedEdge.swift
+++ b/Sources/SwiftGraph/WeightedEdge.swift
@@ -39,6 +39,11 @@ open class WeightedEdge<W: Comparable & Summable>: UnweightedEdge, Comparable {
         self.weight = weight
         super.init(u: u, v: v, directed: directed)
     }
+
+    public override func isEqualTo(_ other: Edge) -> Bool {
+        guard let _other = other as? WeightedEdge else { return false }
+        return self == _other
+    }
     
     //Implement Printable protocol
     public override var description: String {

--- a/SwiftGraph.xcodeproj/project.pbxproj
+++ b/SwiftGraph.xcodeproj/project.pbxproj
@@ -33,6 +33,9 @@
 		7985B9291E5A503200C100E7 /* Sort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 553746441DA56CC500C0E0F6 /* Sort.swift */; };
 		7985B92A1E5A503200C100E7 /* Stack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5589B4771C0E759800D6664E /* Stack.swift */; };
 		7985B92B1E5A503200C100E7 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5589B47A1C0E75A700D6664E /* Queue.swift */; };
+		B5A08A4220794345003845CD /* WeightedGraphEqualityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A08A402079426C003845CD /* WeightedGraphEqualityTests.swift */; };
+		B5A08A4520794421003845CD /* GraphEqualityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A08A432079441A003845CD /* GraphEqualityTests.swift */; };
+		B5FB91B520790B8E000D0CF0 /* ArrayCompareElements.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FB91B420790B8E000D0CF0 /* ArrayCompareElements.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -96,6 +99,9 @@
 		7985B91A1E5A4FCB00C100E7 /* SwiftGraphSearchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftGraphSearchTests.swift; sourceTree = "<group>"; };
 		7985B91B1E5A4FCB00C100E7 /* SwiftGraphSortTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftGraphSortTests.swift; sourceTree = "<group>"; };
 		7985B91C1E5A4FCB00C100E7 /* SwiftGraphTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftGraphTests.swift; sourceTree = "<group>"; };
+		B5A08A402079426C003845CD /* WeightedGraphEqualityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeightedGraphEqualityTests.swift; sourceTree = "<group>"; };
+		B5A08A432079441A003845CD /* GraphEqualityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphEqualityTests.swift; sourceTree = "<group>"; };
+		B5FB91B420790B8E000D0CF0 /* ArrayCompareElements.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ArrayCompareElements.swift; path = Sources/SwiftGraph/ArrayCompareElements.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -204,6 +210,7 @@
 		7985B8FC1E5A4FB800C100E7 /* SwiftGraph */ = {
 			isa = PBXGroup;
 			children = (
+				B5FB91B620790B95000D0CF0 /* Utils */,
 				5589B4811C0E774300D6664E /* Edges */,
 				5589B4821C0E774F00D6664E /* Graphs */,
 				5589B4831C0E775800D6664E /* Search */,
@@ -223,9 +230,19 @@
 				7985B91A1E5A4FCB00C100E7 /* SwiftGraphSearchTests.swift */,
 				7985B91B1E5A4FCB00C100E7 /* SwiftGraphSortTests.swift */,
 				7985B91C1E5A4FCB00C100E7 /* SwiftGraphTests.swift */,
+				B5A08A432079441A003845CD /* GraphEqualityTests.swift */,
+				B5A08A402079426C003845CD /* WeightedGraphEqualityTests.swift */,
 			);
 			name = SwiftGraphTests;
 			path = Tests/SwiftGraphTests;
+			sourceTree = "<group>";
+		};
+		B5FB91B620790B95000D0CF0 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				B5FB91B420790B8E000D0CF0 /* ArrayCompareElements.swift */,
+			);
+			name = Utils;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -396,6 +413,7 @@
 				7985B9211E5A503200C100E7 /* Edge.swift in Sources */,
 				7985B9271E5A503200C100E7 /* SwiftPriorityQueue.swift in Sources */,
 				55DCCBF61F8ADA12001913F7 /* Cycle.swift in Sources */,
+				B5FB91B520790B8E000D0CF0 /* ArrayCompareElements.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -407,8 +425,10 @@
 				7985B91E1E5A4FCB00C100E7 /* SwiftGraphSearchTests.swift in Sources */,
 				55DCCBF81F8AE2F1001913F7 /* CycleTests.swift in Sources */,
 				55E784281ED2971E003899D0 /* MSTTests.swift in Sources */,
+				B5A08A4520794421003845CD /* GraphEqualityTests.swift in Sources */,
 				7985B91D1E5A4FCB00C100E7 /* DijkstraGraphTests.swift in Sources */,
 				7985B91F1E5A4FCB00C100E7 /* SwiftGraphSortTests.swift in Sources */,
+				B5A08A4220794345003845CD /* WeightedGraphEqualityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -7,5 +7,7 @@ XCTMain([
     testCase(SwiftGraphSearchTests.allTests),
     testCase(SwiftGraphSortTests.allTests),
     testCase(SwiftGraphTests.allTests),
+    testCase(GraphEqualityTests.allTests),
+    testCase(WeightedGraphEqualityTests.allTests),
     testCase(CycleTests.allTests),
 ])

--- a/Tests/SwiftGraphTests/GraphEqualityTests.swift
+++ b/Tests/SwiftGraphTests/GraphEqualityTests.swift
@@ -1,0 +1,130 @@
+//
+//  GraphEqualityTests.swift
+//  SwiftGraph
+//
+//  Copyright (c) 2018 Ferran Pujol Camins
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import XCTest
+@testable import SwiftGraph
+
+fileprivate extension Graph {
+    fileprivate func addEdge(from: Int, to: Int, directed: Bool = false) {
+        addEdge(UnweightedEdge(u: from, v: to, directed: directed))
+    }
+    
+    fileprivate func addEdge(from: V, to: V, directed: Bool = false) {
+        if let u = indexOfVertex(from) {
+            if let v = indexOfVertex(to) {
+                addEdge(UnweightedEdge(u: u, v: v, directed: directed))
+            }
+        }
+    }
+}
+
+class GraphEqualityTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testReflexivity() {
+        let g = Graph<String>()
+        XCTAssert(g == g, "Expected empty graph to be equal to itself, but equality check failed")
+        
+        _ = g.addVertex("A");
+        _ = g.addVertex("B");
+        XCTAssert(g == g, "Expected graph without edges to be equal to itself, but equality check failed")
+        
+        g.addEdge(from: "A", to: "B")
+        XCTAssert(g == g, "Expected graph to be equal to itself, but equality check failed")
+    }
+    
+    func testEqualityAndSimmetry() {
+        let g1 = Graph<String>()
+        let g2 = Graph<String>()
+        XCTAssert(g1 == g2, "Expected empty graphs to be equal, but equality check failed")
+        XCTAssert(g2 == g1, "Expected empty graphs to be simmetrically equal, but equality check failed")
+        
+        _ = g1.addVertex("A")
+        _ = g1.addVertex("B")
+        _ = g2.addVertex("A")
+        _ = g2.addVertex("B")
+        XCTAssert(g1 == g2, "Expected graphs without edges to be equal, but equality check failed")
+        XCTAssert(g2 == g1, "Expected graphs without edges to be simmetrically equal, but equality check failed")
+        
+        g1.addEdge(from: "A", to: "B")
+        g2.addEdge(from: "A", to: "B")
+        XCTAssert(g1 == g2, "Expected graphs to be equal, but equality check failed")
+        XCTAssert(g2 == g1, "Expected graphs to be simmetrically equal, but equality check failed")
+    }
+    
+    func testEqualityFailWhenVerticesDifference() {
+        var g1: Graph<String>
+        var g2: Graph<String>
+    
+        g1 = Graph<String>(vertices:["A"])
+        g2 = Graph<String>()
+        XCTAssert(g1 != g2, "Expected empty graph to be different to non-empty graph, but equality check succeeded")
+        
+        g1 = Graph<String>(vertices:["A", "B"])
+        g2 = Graph<String>(vertices:["A"])
+        XCTAssert(g1 != g2, "Expected graphs with different number of vertices to be different, but equality check succeeded")
+        
+        g1 = Graph<String>(vertices:["A", "B"])
+        g2 = Graph<String>(vertices:["A", "C"])
+        XCTAssert(g1 != g2, "Expected graphs with different vertices sets to be different, but equality check succeeded")
+    }
+
+    func testEqualityFailWhenEdgesDifference() {
+        let g1 = Graph<String>(vertices:["A", "B", "C"])
+        let g2 = Graph<String>(vertices:["A", "B", "C"])
+        
+        g1.addEdge(from: "A", to: "B")
+        XCTAssert(g1 != g2, "Expected graph with no edges to be different to graph with edges, but equality check succeeded")
+        
+        g1.addEdge(from: "A", to: "B")
+        g1.addEdge(from: "A", to: "C")
+        g2.addEdge(from: "A", to: "B")
+        XCTAssert(g1 != g2, "Expected graphs with different number of edges to be different, but equality check succeeded")
+        
+        g1.addEdge(from: "A", to: "B")
+        g2.addEdge(from: "A", to: "C")
+        XCTAssert(g1 != g2, "Expected graphs with different edges sets to be different, but equality check succeeded")
+        
+        XCTAssert(g1 != g2, "Expected graphs to be different, but equality check succeeded")
+    }
+    
+    func testEqualityWithRepeatedVertices() {
+        let g1 = Graph<String>(vertices:["A", "A", "A"])
+        g1.addEdge(from: 0, to: 1)
+        
+        let g2 = Graph<String>(vertices:["A", "A", "A"])
+        g2.addEdge(from: 1, to: 2)
+        XCTAssert(g1 != g2, "Expected graphs with different edges to be different, but equality check succeeded")
+    }
+
+    static var allTests = [
+        ("testReflexivity", testReflexivity),
+        ("testEqualityAndSimmetry", testEqualityAndSimmetry),
+        ("testEqualityFailWhenVerticesDifference", testEqualityFailWhenVerticesDifference),
+        ("testEqualityFailWhenEdgesDifference", testEqualityFailWhenEdgesDifference),
+        ("testEqualityWithRepeatedVertices", testEqualityWithRepeatedVertices)
+    ]
+}

--- a/Tests/SwiftGraphTests/UnweightedGraphEqualityTests.swift
+++ b/Tests/SwiftGraphTests/UnweightedGraphEqualityTests.swift
@@ -1,0 +1,106 @@
+//
+//  UnweightedGraphEqualityTests.swift
+//  SwiftGraph
+//
+//  Copyright (c) 2018 Ferran Pujol Camins
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import XCTest
+@testable import SwiftGraph
+
+class UnweightedGraphEqualityTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testReflexivity() {
+        let g = UnweightedGraph<String>()
+        XCTAssert(g == g, "Expected empty graph to be equal to itself, but equality check failed")
+        
+        _ = g.addVertex("A");
+        _ = g.addVertex("B");
+        XCTAssert(g == g, "Expected graph without edges to be equal to itself, but equality check failed")
+        
+        g.addEdge(from: "A", to: "B")
+        XCTAssert(g == g, "Expected graph to be equal to itself, but equality check failed")
+    }
+    
+    func testEqualityAndSimmetry() {
+        let g1 = UnweightedGraph<String>()
+        let g2 = UnweightedGraph<String>()
+        XCTAssert(g1 == g2, "Expected empty graphs to be equal, but equality check failed")
+        XCTAssert(g2 == g1, "Expected empty graphs to be simmetrically equal, but equality check failed")
+        
+        _ = g1.addVertex("A");
+        _ = g1.addVertex("B");
+        _ = g2.addVertex("A");
+        _ = g2.addVertex("B");
+        XCTAssert(g1 == g2, "Expected graphs without edges to be equal, but equality check failed")
+        XCTAssert(g2 == g1, "Expected graphs without edges to be simmetrically equal, but equality check failed")
+        
+        g1.addEdge(from: "A", to: "B")
+        g2.addEdge(from: "A", to: "B")
+        XCTAssert(g1 == g2, "Expected graphs to be equal, but equality check failed")
+        XCTAssert(g2 == g1, "Expected graphs to be simmetrically equal, but equality check failed")
+    }
+    
+    func testEqualityFailWhenVerticesDifference() {
+        var g1: UnweightedGraph<String>;
+        var g2: UnweightedGraph<String>;
+    
+        g1 = UnweightedGraph<String>(vertices:["A"])
+        g2 = UnweightedGraph<String>()
+        XCTAssert(g1 != g2, "Expected empty graph to be different to non-empty graph, but equality check succeeded")
+        
+        g1 = UnweightedGraph<String>(vertices:["A", "B"])
+        g2 = UnweightedGraph<String>(vertices:["A"])
+        XCTAssert(g1 != g2, "Expected graphs with different number of vertices to be different, but equality check succeeded")
+        
+        g1 = UnweightedGraph<String>(vertices:["A", "B"])
+        g2 = UnweightedGraph<String>(vertices:["A", "C"])
+        XCTAssert(g1 != g2, "Expected graphs with different vertices sets to be different, but equality check succeeded")
+    }
+
+    func testEqualityFailWhenEdgesDifference() {
+        let g1 = UnweightedGraph<String>(vertices:["A", "B", "C"]);
+        let g2 = UnweightedGraph<String>(vertices:["A", "B", "C"]);
+        
+        g1.addEdge(from: "A", to: "B")
+        XCTAssert(g1 != g2, "Expected graph with no edges to be different to graph with edges, but equality check succeeded")
+        
+        g1.addEdge(from: "A", to: "B")
+        g1.addEdge(from: "A", to: "C")
+        g2.addEdge(from: "A", to: "B")
+        XCTAssert(g1 != g2, "Expected graphs with different number of edges to be different, but equality check succeeded")
+        
+        g1.addEdge(from: "A", to: "B")
+        g2.addEdge(from: "A", to: "C")
+        XCTAssert(g1 != g2, "Expected graphs with different edges sets to be different, but equality check succeeded")
+        
+        XCTAssert(g1 != g2, "Expected graphs to be different, but equality check succeeded")
+    }
+
+    static var allTests = [
+        ("testReflexivity", testReflexivity),
+        ("testEqualityAndSimmetry", testEqualityAndSimmetry),
+        ("testEqualityFailWhenVerticesDifference", testEqualityFailWhenVerticesDifference),
+        ("testEqualityFailWhenEdgesDifference", testEqualityFailWhenEdgesDifference),
+    ]
+}

--- a/Tests/SwiftGraphTests/WeightedGraphEqualityTests.swift
+++ b/Tests/SwiftGraphTests/WeightedGraphEqualityTests.swift
@@ -1,0 +1,57 @@
+//
+//  WeightedGraphEqualityTests.swift
+//  SwiftGraph
+//
+//  Copyright (c) 2018 Ferran Pujol Camins
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import XCTest
+@testable import SwiftGraph
+
+class WeightedGraphEqualityTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testReflexivity() {
+        let g = WeightedGraph<String, Double>(vertices:["A", "B"])
+        g.addEdge(from: "A", to: "B", weight: 3)
+        XCTAssert(g == g, "Expected graph to be equal to itself, but equality check failed")
+    }
+    
+    func testEqualityAndSimmetry() {
+        let g1 = WeightedGraph<String, Double>(vertices:["A", "B"])
+        let g2 = WeightedGraph<String, Double>(vertices:["A", "B"])
+        
+        g1.addEdge(from: "A", to: "B", weight: 1)
+        g2.addEdge(from: "A", to: "B", weight: 1)
+        XCTAssert(g1 == g2, "Expected graphs to be equal, but equality check failed")
+        XCTAssert(g2 == g1, "Expected graphs to be simmetrically equal, but equality check failed")
+        
+        g2.removeAllEdges(from: "A", to: "B", bidirectional: true)
+        g2.addEdge(from: "A", to: "B", weight: 2)
+        XCTAssert(g1 == g2, "Expected graphs to be different, but equality check succeeded")
+    }
+
+    static var allTests = [
+        ("testReflexivity", testReflexivity),
+        ("testEqualityAndSimmetry", testEqualityAndSimmetry),
+    ]
+}


### PR DESCRIPTION
As discussed [in this issue](https://github.com/davecom/SwiftGraph/issues/35), this is a first step towards a SetAlgebra conformant subclass of Graph. SetAlgebra inherits from Equatable, so Equatable needed to be implemented. Since it makes sense to check for graph equality, I implemented it for Graph basse class.

When a protocol inherits from Equatable it cannot be used as type anymore. This was a problem with Edge. To solve it, a type erased AnyEquatableEdge is created. See [this link](https://khawerkhaliq.com/blog/swift-protocols-equatable-part-two/) for details.