### PR TITLE
Add UnweightedGraph initializers for path and cycle

### DIFF
--- a/Sources/SwiftGraph/UnweightedGraph.swift
+++ b/Sources/SwiftGraph/UnweightedGraph.swift
@@ -25,6 +25,56 @@ open class UnweightedGraph<T: Equatable>: Graph<T> {
     public override init(vertices: [T]) {
         super.init(vertices: vertices)
     }
+
+
+    /// Initialize an UnweightedGraph consisting of path.
+    ///
+    /// The resulting graph has the vertices in path and an edge between
+    /// each pair of consecutive vertices in path.
+    ///
+    /// If path is an empty array, the resulting graph is the empty graph.
+    /// If path is an array with a single vertex, the resulting graph has that vertex and no edges.
+    ///
+    /// - Parameters:
+    ///   - path: An array of vertices representing a path.
+    ///   - directed: If false, undirected edges are created.
+    ///               If true, edges are directed from vertex i to vertex i+1 in path.
+    ///               Default is false.
+    public convenience init(withPath path: [T], directed: Bool = false) {
+        self.init(vertices: path)
+
+        guard path.count >= 2 else {
+            return
+        }
+
+        for i in 0..<path.count - 1 {
+            let vertices = path[i...i+1]
+            self.addEdge(from: vertices.first!, to: vertices.last!, directed: directed)
+        }
+    }
+
+    /// Initialize an UnweightedGraph consisting of cycle.
+    ///
+    /// The resulting graph has the vertices in cycle and an edge between
+    /// each pair of consecutive vertices in cycle,
+    /// plus an edge between the last and the first vertices.
+    ///
+    /// If path is an empty array, the resulting graph is the empty graph.
+    /// If path is an array with a single vertex, the resulting graph has the vertex
+    /// and a single edge to itself if directed is true.
+    /// If directed is false the resulting graph has the vertex and two edges to itself.
+    ///
+    /// - Parameters:
+    ///   - cycle: An array of vertices representing a cycle.
+    ///   - directed: If false, undirected edges are created.
+    ///               If true, edges are directed from vertex i to vertex i+1 in cycle.
+    ///               Default is false.
+    public convenience init(withCycle cycle: [T], directed: Bool = false) {
+        self.init(withPath: cycle, directed: directed)
+        if cycle.count > 0 {
+            self.addEdge(from: cycle.last!, to: cycle.first!, directed: directed)
+        }
+    }
     
     /// This is a convenience method that adds an unweighted edge.
     ///

--- a/SwiftGraph.xcodeproj/project.pbxproj
+++ b/SwiftGraph.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		7985B9291E5A503200C100E7 /* Sort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 553746441DA56CC500C0E0F6 /* Sort.swift */; };
 		7985B92A1E5A503200C100E7 /* Stack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5589B4771C0E759800D6664E /* Stack.swift */; };
 		7985B92B1E5A503200C100E7 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5589B47A1C0E75A700D6664E /* Queue.swift */; };
+		B5100A4D208B97AA00C7A73A /* UnweightedGraphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5100A4B208B97A800C7A73A /* UnweightedGraphTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -96,6 +97,7 @@
 		7985B91A1E5A4FCB00C100E7 /* SwiftGraphSearchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftGraphSearchTests.swift; sourceTree = "<group>"; };
 		7985B91B1E5A4FCB00C100E7 /* SwiftGraphSortTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftGraphSortTests.swift; sourceTree = "<group>"; };
 		7985B91C1E5A4FCB00C100E7 /* SwiftGraphTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftGraphTests.swift; sourceTree = "<group>"; };
+		B5100A4B208B97A800C7A73A /* UnweightedGraphTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnweightedGraphTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -223,6 +225,7 @@
 				7985B91A1E5A4FCB00C100E7 /* SwiftGraphSearchTests.swift */,
 				7985B91B1E5A4FCB00C100E7 /* SwiftGraphSortTests.swift */,
 				7985B91C1E5A4FCB00C100E7 /* SwiftGraphTests.swift */,
+				B5100A4B208B97A800C7A73A /* UnweightedGraphTests.swift */,
 			);
 			name = SwiftGraphTests;
 			path = Tests/SwiftGraphTests;
@@ -407,6 +410,7 @@
 				7985B91E1E5A4FCB00C100E7 /* SwiftGraphSearchTests.swift in Sources */,
 				55DCCBF81F8AE2F1001913F7 /* CycleTests.swift in Sources */,
 				55E784281ED2971E003899D0 /* MSTTests.swift in Sources */,
+				B5100A4D208B97AA00C7A73A /* UnweightedGraphTests.swift in Sources */,
 				7985B91D1E5A4FCB00C100E7 /* DijkstraGraphTests.swift in Sources */,
 				7985B91F1E5A4FCB00C100E7 /* SwiftGraphSortTests.swift in Sources */,
 			);

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -7,5 +7,6 @@ XCTMain([
     testCase(SwiftGraphSearchTests.allTests),
     testCase(SwiftGraphSortTests.allTests),
     testCase(SwiftGraphTests.allTests),
+    testCase(UnweightedGraphTests.allTests),
     testCase(CycleTests.allTests),
 ])

--- a/Tests/SwiftGraphTests/UnweightedGraphTests.swift
+++ b/Tests/SwiftGraphTests/UnweightedGraphTests.swift
@@ -1,0 +1,137 @@
+//
+//  UnweightedGraphTests.swift
+//  SwiftGraphTests
+//
+//  Copyright (c) 2018 Ferran Pujol Camins
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import XCTest
+@testable import SwiftGraph
+
+class UnweightedGraphTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testPathInitializerUndirected() {
+        let g0Path = UnweightedGraph<String>(withPath:[])
+        XCTAssertEqual(g0Path.vertexCount, 0, "g0Path: Expected empty graph")
+        XCTAssertEqual(g0Path.edgeCount, 0, "g0Path: Expected empty graph")
+
+        let g1Path = UnweightedGraph(withPath:["Atlanta"])
+        XCTAssertEqual(g1Path.vertices, ["Atlanta"], "g1Path: Expected only Atlanta vertex")
+        XCTAssertEqual(g1Path.edgeCount, 0, "g1Path: Expected no edges")
+
+        let g2Path = UnweightedGraph(withPath:["Atlanta", "Boston"])
+        XCTAssertEqual(g2Path.vertices, ["Atlanta", "Boston"], "g2Path: Expected vertices to be Atlanta and Boston")
+        XCTAssertEqual(g2Path.edgeCount, 2, "g2Path: Expected exactly 2 edges")
+        XCTAssertTrue(g2Path.edgeExists(from: "Atlanta", to: "Boston"), "g2Path: Expected an edge from Atlanta to Boston")
+        XCTAssertTrue(g2Path.edgeExists(from: "Boston", to: "Atlanta"), "g2Path: Expected an edge from Boston to Atlanta")
+
+        let g3Path = UnweightedGraph(withPath:["Atlanta", "Boston", "Chicago"])
+        XCTAssertEqual(g3Path.vertices, ["Atlanta", "Boston", "Chicago"], "g3Path: Expected vertices to be Atlanta, Boston and Chicago")
+        XCTAssertEqual(g3Path.edgeCount, 4, "g3Path: Expected exactly 4 edges")
+        XCTAssertTrue(g3Path.edgeExists(from: "Atlanta", to: "Boston"), "g3Path: Expected an edge from Atlanta to Boston")
+        XCTAssertTrue(g3Path.edgeExists(from: "Boston", to: "Atlanta"), "g3Path: Expected an edge from Boston to Atlanta")
+        XCTAssertTrue(g3Path.edgeExists(from: "Boston", to: "Chicago"), "g3Path: Expected an edge from Boston to Chicago")
+        XCTAssertTrue(g3Path.edgeExists(from: "Chicago", to: "Boston"), "g3Path: Expected an edge from Chicago to Boston")
+    }
+
+    func testPathInitializerDirected() {
+        let g0Path = UnweightedGraph<String>(withPath:[], directed: true)
+        XCTAssertEqual(g0Path.vertexCount, 0, "g0Path: Expected empty graph")
+        XCTAssertEqual(g0Path.edgeCount, 0, "g0Path: Expected empty graph")
+
+        let g1Path = UnweightedGraph(withPath:["Atlanta"], directed: true)
+        XCTAssertEqual(g1Path.vertices, ["Atlanta"], "g1Path: Expected only Atlanta vertex")
+        XCTAssertEqual(g1Path.edgeCount, 0, "g1Path: Expected no edges")
+
+        let g2Path = UnweightedGraph(withPath:["Atlanta", "Boston"], directed: true)
+        XCTAssertEqual(g2Path.vertices, ["Atlanta", "Boston"], "g2Path: Expected vertices to be Atlanta and Boston")
+        XCTAssertEqual(g2Path.edgeCount, 1, "g2Path: Expected exactly 1 edges")
+        XCTAssertTrue(g2Path.edgeExists(from: "Atlanta", to: "Boston"), "g2Path: Expected an edge from Atlanta to Boston")
+
+        let g3Path = UnweightedGraph(withPath:["Atlanta", "Boston", "Chicago"], directed: true)
+        XCTAssertEqual(g3Path.vertices, ["Atlanta", "Boston", "Chicago"], "g3Path: Expected vertices to be Atlanta, Boston and Chicago")
+        XCTAssertEqual(g3Path.edgeCount, 2, "g3Path: Expected exactly 2 edges")
+        XCTAssertTrue(g3Path.edgeExists(from: "Atlanta", to: "Boston"), "g3Path: Expected an edge from Atlanta to Boston")
+        XCTAssertTrue(g3Path.edgeExists(from: "Boston", to: "Chicago"), "g3Path: Expected an edge from Boston to Chicago")
+    }
+
+    func testCycleInitializerUndirected() {
+        let g0Cycle = UnweightedGraph<String>(withCycle:[])
+        XCTAssertEqual(g0Cycle.vertexCount, 0, "g0Cycle: Expected empty graph")
+        XCTAssertEqual(g0Cycle.edgeCount, 0, "g0Cycle: Expected empty graph")
+
+        let g1Cycle = UnweightedGraph(withCycle:["Atlanta"])
+        XCTAssertEqual(g1Cycle.vertices, ["Atlanta"], "g1Cycle: Expected only Atlanta vertex")
+        XCTAssertEqual(g1Cycle.edgeCount, 2, "g1Cycle: Expected 2 edges")
+        XCTAssertTrue(g1Cycle.edgeExists(from: "Atlanta", to: "Atlanta"), "g1Cycle: Expected an edge from Atlanta to Atlanta")
+
+        let g2Cycle = UnweightedGraph(withCycle:["Atlanta", "Boston"])
+        XCTAssertEqual(g2Cycle.vertices, ["Atlanta", "Boston"], "g2Cycle: Expected vertices to be Atlanta and Boston")
+        XCTAssertEqual(g2Cycle.edgeCount, 4, "g2Cycle: Expected exactly 4 edges")
+        XCTAssertTrue(g2Cycle.edgeExists(from: "Atlanta", to: "Boston"), "g2Cycle: Expected an edge from Atlanta to Boston")
+        XCTAssertTrue(g2Cycle.edgeExists(from: "Boston", to: "Atlanta"), "g2Cycle: Expected an edge from Boston to Atlanta")
+
+        let g3Cycle = UnweightedGraph(withCycle:["Atlanta", "Boston", "Chicago"])
+        XCTAssertEqual(g3Cycle.vertices, ["Atlanta", "Boston", "Chicago"], "g3Cycle: Expected vertices to be Atlanta, Boston and Chicago")
+        XCTAssertEqual(g3Cycle.edgeCount, 6, "g3Path: Expected exactly 4 edges")
+        XCTAssertTrue(g3Cycle.edgeExists(from: "Atlanta", to: "Boston"), "g3Cycle: Expected an edge from Atlanta to Boston")
+        XCTAssertTrue(g3Cycle.edgeExists(from: "Boston", to: "Atlanta"), "g3Cycle: Expected an edge from Boston to Atlanta")
+        XCTAssertTrue(g3Cycle.edgeExists(from: "Boston", to: "Chicago"), "g3Cycle: Expected an edge from Boston to Chicago")
+        XCTAssertTrue(g3Cycle.edgeExists(from: "Chicago", to: "Boston"), "g3Cycle: Expected an edge from Chicago to Boston")
+        XCTAssertTrue(g3Cycle.edgeExists(from: "Chicago", to: "Atlanta"), "g3Cycle: Expected an edge from Chicago to Atlanta")
+        XCTAssertTrue(g3Cycle.edgeExists(from: "Atlanta", to: "Chicago"), "g3Cycle: Expected an edge from Atlanta to Chicago")
+    }
+
+    func testCycleInitializerDirected() {
+        let g0Cycle = UnweightedGraph<String>(withCycle:[], directed: true)
+        XCTAssertEqual(g0Cycle.vertexCount, 0, "g0Cycle: Expected empty graph")
+        XCTAssertEqual(g0Cycle.edgeCount, 0, "g0Cycle: Expected empty graph")
+
+        let g1Cycle = UnweightedGraph(withCycle:["Atlanta"], directed: true)
+        XCTAssertEqual(g1Cycle.vertices, ["Atlanta"], "g1Cycle: Expected only Atlanta vertex")
+        XCTAssertEqual(g1Cycle.edgeCount, 1, "g1Cycle: Expected 1 edge")
+        XCTAssertTrue(g1Cycle.edgeExists(from: "Atlanta", to: "Atlanta"), "g1Cycle: Expected an edge from Atlanta to Atlanta")
+
+        let g2Cycle = UnweightedGraph(withCycle:["Atlanta", "Boston"], directed: true)
+        XCTAssertEqual(g2Cycle.vertices, ["Atlanta", "Boston"], "g2Cycle: Expected vertices to be Atlanta and Boston")
+        XCTAssertEqual(g2Cycle.edgeCount, 2, "g2Cycle: Expected exactly 2 edges")
+        XCTAssertTrue(g2Cycle.edgeExists(from: "Atlanta", to: "Boston"), "g2Cycle: Expected an edge from Atlanta to Boston")
+        XCTAssertTrue(g2Cycle.edgeExists(from: "Boston", to: "Atlanta"), "g2Cycle: Expected an edge from Atlanta to Boston")
+
+        let g3Cycle = UnweightedGraph(withCycle:["Atlanta", "Boston", "Chicago"], directed: true)
+        XCTAssertEqual(g3Cycle.vertices, ["Atlanta", "Boston", "Chicago"], "g3Cycle: Expected vertices to be Atlanta, Boston and Chicago")
+        XCTAssertEqual(g3Cycle.edgeCount, 3, "g3Cycle: Expected exactly 4 edges")
+        XCTAssertTrue(g3Cycle.edgeExists(from: "Atlanta", to: "Boston"), "g3Cycle: Expected an edge from Atlanta to Boston")
+        XCTAssertTrue(g3Cycle.edgeExists(from: "Boston", to: "Chicago"), "g3Cycle: Expected an edge from Boston to Chicago")
+        XCTAssertTrue(g3Cycle.edgeExists(from: "Chicago", to: "Atlanta"), "g3Cycle: Expected an edge from Chicago to Atlanta")
+    }
+
+    static var allTests = [
+        ("testPathInitializerDirected", testPathInitializerDirected),
+        ("testPathInitializerUndirected", testPathInitializerUndirected),
+        ("testCycleInitializerDirected", testCycleInitializerDirected),
+        ("testCycleInitializerUndirected", testCycleInitializerUndirected)
+    ]
+}
+


### PR DESCRIPTION
This PR adds two convenience initializers for UnweightedGraph. The initilizers let you create a path or cycle graph by providing a list of vertices. The initializer creates a graph with the vertices and edges between them.

With this an the coming soon DisjointUnion, we will be able to create graphs by listing its paths or cycles.