### PR TITLE
Codable support

### DIFF
--- a/Sources/SwiftGraph/Graph.swift
+++ b/Sources/SwiftGraph/Graph.swift
@@ -19,7 +19,7 @@
 /// The superclass for all graphs. Defined as a class instead of a protocol so that its subclasses can
 /// have some method implementations in common. You should generally use one of its two canonical subclasses,
 /// *UnweightedGraph* and *WeightedGraph*, because they offer more functionality and convenience.
-open class Graph<V: Equatable>: CustomStringConvertible, Sequence, Collection {
+open class Graph<V: Equatable & Codable>: CustomStringConvertible, Sequence, Collection, Codable {
     var vertices: [V] = [V]()
     var edges: [[Edge]] = [[Edge]]() //adjacency lists
     
@@ -286,5 +286,21 @@ open class Graph<V: Equatable>: CustomStringConvertible, Sequence, Collection {
     /// - returns: The vertex at index.
     public subscript(i: Int) -> V {
         return vertexAtIndex(i)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case vertices = "vertices"
+        case edges = "edges"
+    }
+    
+    public required init(from decoder: Decoder) throws  {
+        let rootContainer = try decoder.container(keyedBy: CodingKeys.self)
+        let vertices = try rootContainer.decode([V].self, forKey: CodingKeys.vertices)
+        self.vertices = vertices
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var rootContainer = encoder.container(keyedBy: CodingKeys.self)
+        try rootContainer.encode(self.vertices, forKey: CodingKeys.vertices)
     }
 }

--- a/Sources/SwiftGraph/UniqueElementsGraph.swift
+++ b/Sources/SwiftGraph/UniqueElementsGraph.swift
@@ -17,7 +17,7 @@
 //  limitations under the License.
 
 /// A subclass of UnweightedGraph that ensures there are no pairs of equal vertices and no repeated edges.
-open class UniqueElementsGraph<V: Equatable>: UnweightedGraph<V> {
+open class UniqueElementsGraph<V: Equatable & Codable>: UnweightedGraph<V> {
 
     public override init() {
         super.init()
@@ -27,7 +27,11 @@ open class UniqueElementsGraph<V: Equatable>: UnweightedGraph<V> {
     public override init(vertices: [V]) {
         super.init(vertices: vertices)
     }
-
+    
+    public required init(from decoder: Decoder) throws {
+        fatalError("init(from:) has not been implemented")
+    }
+    
     /// Add a vertex to the graph if no equal vertex already belongs to the Graph. O(n)
     ///
     /// - parameter v: The vertex to be added.

--- a/Sources/SwiftGraph/UnweightedEdge.swift
+++ b/Sources/SwiftGraph/UnweightedEdge.swift
@@ -17,7 +17,7 @@
 //  limitations under the License.
 
 /// A basic unweighted edge.
-open class UnweightedEdge: Edge, Equatable, CustomStringConvertible {
+open class UnweightedEdge: Edge, Equatable, CustomStringConvertible, Codable {
     public var u: Int
     public var v: Int
     public var weighted: Bool { return false }
@@ -43,5 +43,28 @@ open class UnweightedEdge: Edge, Equatable, CustomStringConvertible {
     //MARK: Operator Overloads
     static public func ==(lhs: UnweightedEdge, rhs: UnweightedEdge) -> Bool {
         return lhs.u == rhs.u && lhs.v == rhs.v && lhs.directed == rhs.directed
+    }
+    
+    //MARK: Codable
+    /// An enum with all of UnweightedEdge's encoding and decoding members.
+    fileprivate enum CodingKeys: String, CodingKey {
+        case u = "u"
+        case v = "v"
+        case weighted = "weighted"
+        case directed = "directed"
+    }
+    
+    public required init(from decoder: Decoder) throws {
+        let rootContainer = try decoder.container(keyedBy: CodingKeys.self)
+        self.u = try rootContainer.decode(Int.self, forKey: CodingKeys.u)
+        self.v = try rootContainer.decode(Int.self, forKey: CodingKeys.v)
+        self.directed = try rootContainer.decode(Bool.self, forKey: CodingKeys.directed)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var rootContainer = encoder.container(keyedBy: CodingKeys.self)
+        try rootContainer.encode(self.u, forKey: CodingKeys.u)
+        try rootContainer.encode(self.v, forKey: CodingKeys.v)
+        try rootContainer.encode(self.directed, forKey: CodingKeys.directed)
     }
 }

--- a/Sources/SwiftGraph/WeightedEdge.swift
+++ b/Sources/SwiftGraph/WeightedEdge.swift
@@ -28,7 +28,7 @@ extension Float: Summable {}
 extension String: Summable {}
 
 /// A weighted edge, who's weight subscribes to Comparable.
-open class WeightedEdge<W: Comparable & Summable>: UnweightedEdge, Comparable {
+open class WeightedEdge<W: Comparable & Summable & Codable>: UnweightedEdge, Comparable {
     public override var weighted: Bool { return true }
     public let weight: W
     public override var reversed:Edge {
@@ -56,4 +56,24 @@ open class WeightedEdge<W: Comparable & Summable>: UnweightedEdge, Comparable {
     static public func < <W>(lhs: WeightedEdge<W>, rhs: WeightedEdge<W>) -> Bool {
         return lhs.weight < rhs.weight
     }
+    
+    //MARK: Codable
+    /// An enum with all of WeightedEdge's encoding and decoding members.
+    fileprivate enum CodingKeys: String, CodingKey {
+        case weight = "weight"
+    }
+    
+    public required init(from decoder: Decoder) throws {
+        let rootContainer = try decoder.container(keyedBy: CodingKeys.self)
+        self.weight = try rootContainer.decode(W.self, forKey: CodingKeys.weight)
+
+        try super.init(from: decoder)
+    }
+    
+    override public func encode(to encoder: Encoder) throws {
+        try super.encode(to: encoder)
+        var rootContainer = encoder.container(keyedBy: CodingKeys.self)
+        try rootContainer.encode(self.weight, forKey: CodingKeys.weight)
+    }
 }
+

--- a/SwiftGraph.xcodeproj/project.pbxproj
+++ b/SwiftGraph.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C4DE653214B742400985BBB /* SwiftGraphCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4DE651214B73E800985BBB /* SwiftGraphCodableTests.swift */; };
 		55DCCBF61F8ADA12001913F7 /* Cycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DCCBF51F8ADA12001913F7 /* Cycle.swift */; };
 		55DCCBF81F8AE2F1001913F7 /* CycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DCCBF71F8AE2F1001913F7 /* CycleTests.swift */; };
 		55E620081A194C80000A5F7B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E620071A194C80000A5F7B /* AppDelegate.swift */; };
@@ -73,6 +74,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3C4DE651214B73E800985BBB /* SwiftGraphCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftGraphCodableTests.swift; sourceTree = "<group>"; };
 		553746441DA56CC500C0E0F6 /* Sort.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Sort.swift; path = Sources/SwiftGraph/Sort.swift; sourceTree = SOURCE_ROOT; };
 		557F55E91F8AB247002AF0BF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Info.plist; sourceTree = "<group>"; };
 		5589B4621C0E72CC00D6664E /* Edge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Edge.swift; path = Sources/SwiftGraph/Edge.swift; sourceTree = SOURCE_ROOT; };
@@ -238,6 +240,7 @@
 				7985B91A1E5A4FCB00C100E7 /* SwiftGraphSearchTests.swift */,
 				7985B91B1E5A4FCB00C100E7 /* SwiftGraphSortTests.swift */,
 				7985B91C1E5A4FCB00C100E7 /* SwiftGraphTests.swift */,
+				3C4DE651214B73E800985BBB /* SwiftGraphCodableTests.swift */,
 				B5100A4B208B97A800C7A73A /* UnweightedGraphTests.swift */,
 				B52ABD37208955B500FBF10C /* UnionTests.swift */,
 			);
@@ -447,6 +450,7 @@
 				B5100A4D208B97AA00C7A73A /* UnweightedGraphTests.swift in Sources */,
 				7985B91D1E5A4FCB00C100E7 /* DijkstraGraphTests.swift in Sources */,
 				7985B91F1E5A4FCB00C100E7 /* SwiftGraphSortTests.swift in Sources */,
+				3C4DE653214B742400985BBB /* SwiftGraphCodableTests.swift in Sources */,
 				B523F2EA2094F0E2006587ED /* UniqueElementsGraphInitTests.swift in Sources */,
 				B5D229BF207BF3A800151820 /* UniqueElementsGraphTests.swift in Sources */,
 			);

--- a/Tests/SwiftGraphTests/SwiftGraphCodableTests.swift
+++ b/Tests/SwiftGraphTests/SwiftGraphCodableTests.swift
@@ -1,0 +1,258 @@
+//
+//  SwiftGraphCodableTests.swift
+//  SwiftGraph
+//
+//  Created by Ian Grossberg on 9/14/18.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import XCTest
+@testable import SwiftGraph
+
+class SwiftGraphCodableTests: XCTestCase {
+    var expectedUnweightedGraph: UnweightedGraph<String> {
+        let g: UnweightedGraph<String> = UnweightedGraph<String>()
+        _ = g.addVertex("Atlanta")
+        _ = g.addVertex("New York")
+        _ = g.addVertex("Miami")
+        g.addEdge(from: "Atlanta", to: "New York")
+        g.addEdge(from: "Miami", to: "Atlanta")
+        g.addEdge(from: "New York", to: "Miami")
+        g.removeVertex("Atlanta")
+        return g
+    }
+    
+    let expectedString = """
+    {"edges":[[[{"u":0,"v":1,"directed":false}]],[[{"u":1,"v":0,"directed":false}]]],"vertices":["New York","Miami"]}
+    """
+    
+    func testEncodable() {
+        let g = expectedUnweightedGraph
+
+        let jsonData: Data
+        do {
+            jsonData = try JSONEncoder().encode(g)
+        } catch {
+            XCTFail("JSONEncoder().encode(g) threw: \(error)")
+            return
+        }
+        let jsonString = String(data: jsonData, encoding: .utf8)
+        XCTAssertEqual(jsonString, expectedString)
+    }
+    
+    func testDecodable() {
+        guard let jsonData = expectedString.data(using: .utf8) else {
+            XCTFail("Unable to serialize expected JSON string into Data")
+            return
+        }
+        
+        let g: UnweightedGraph<String>
+        do {
+            g = try JSONDecoder().decode(UnweightedGraph<String>.self, from: jsonData)
+        } catch {
+            XCTFail("JSONDecoder().decode(UnweightedGraph<String>.self, from: jsonData) threw: \(error)")
+            return
+        }
+        XCTAssertEqual(g.neighborsForVertex("Miami")!, g.neighborsForVertex(g.neighborsForVertex("New York")![0])!, "Miami and New York Connected bi-directionally")
+//        XCTAssertEqual(g, expectedUnweightedGraph)
+    }
+}
+
+struct SwiftGraphCodableTests_Vertex: Equatable, Hashable, Decodable, Encodable {
+    let int: Int
+    let string: String
+}
+
+struct SwiftGraphCodableTests_Edge: Comparable, Summable, Decodable, Encodable {
+    let weight: Int
+    
+    static func < (lhs: SwiftGraphCodableTests_Edge, rhs: SwiftGraphCodableTests_Edge) -> Bool {
+        return lhs.weight < rhs.weight
+    }
+    
+    static func + (lhs: SwiftGraphCodableTests_Edge, rhs: SwiftGraphCodableTests_Edge) -> SwiftGraphCodableTests_Edge {
+        return SwiftGraphCodableTests_Edge(weight: lhs.weight + rhs.weight)
+    }
+}
+
+extension SwiftGraphCodableTests {
+    func cityGraph() -> WeightedGraph<SwiftGraphCodableTests_Vertex, SwiftGraphCodableTests_Edge> {
+        // pg 1016 Liang
+        let result = WeightedGraph<SwiftGraphCodableTests_Vertex, SwiftGraphCodableTests_Edge>(vertices: [
+            SwiftGraphCodableTests_Vertex(int: 0, string: "Seattle"),
+            SwiftGraphCodableTests_Vertex(int: 1, string: "San Francisco"),
+            SwiftGraphCodableTests_Vertex(int: 2, string: "Los Angeles"),
+            SwiftGraphCodableTests_Vertex(int: 3, string: "Denver"),
+            SwiftGraphCodableTests_Vertex(int: 4, string: "Kansas City"),
+            SwiftGraphCodableTests_Vertex(int: 5, string: "Chicago"),
+            SwiftGraphCodableTests_Vertex(int: 6, string: "Boston"),
+            SwiftGraphCodableTests_Vertex(int: 7, string: "New York"),
+            SwiftGraphCodableTests_Vertex(int: 8, string: "Atlanta"),
+            SwiftGraphCodableTests_Vertex(int: 9, string: "Miami"),
+            SwiftGraphCodableTests_Vertex(int: 10, string: "Dallas"),
+            SwiftGraphCodableTests_Vertex(int: 11, string: "Houston")
+            ])
+        
+        let vertexWithName = { (name: String) -> SwiftGraphCodableTests_Vertex in
+            return result.immutableVertices.filter({ $0.string == name }).first!
+        }
+        // pg 1062 Liang
+        result.addEdge(from: vertexWithName("Seattle"), to: vertexWithName("Chicago"), weight: SwiftGraphCodableTests_Edge(weight: 2097))
+        result.addEdge(from: vertexWithName("Seattle"), to: vertexWithName("Denver"), weight: SwiftGraphCodableTests_Edge(weight: 1331))
+        result.addEdge(from: vertexWithName("Seattle"), to: vertexWithName("San Francisco"), weight: SwiftGraphCodableTests_Edge(weight: 807))
+        result.addEdge(from: vertexWithName("San Francisco"), to: vertexWithName("Denver"), weight: SwiftGraphCodableTests_Edge(weight: 1267))
+        result.addEdge(from: vertexWithName("San Francisco"), to: vertexWithName("Los Angeles"), weight: SwiftGraphCodableTests_Edge(weight: 381))
+        result.addEdge(from: vertexWithName("Los Angeles"), to: vertexWithName("Denver"), weight: SwiftGraphCodableTests_Edge(weight: 1015))
+        result.addEdge(from: vertexWithName("Los Angeles"), to: vertexWithName("Kansas City"), weight: SwiftGraphCodableTests_Edge(weight: 1663))
+        result.addEdge(from: vertexWithName("Los Angeles"), to: vertexWithName("Dallas"), weight: SwiftGraphCodableTests_Edge(weight: 1435))
+        result.addEdge(from: vertexWithName("Denver"), to: vertexWithName("Chicago"), weight: SwiftGraphCodableTests_Edge(weight: 1003))
+        result.addEdge(from: vertexWithName("Denver"), to: vertexWithName("Kansas City"), weight: SwiftGraphCodableTests_Edge(weight: 599))
+        result.addEdge(from: vertexWithName("Kansas City"), to: vertexWithName("Chicago"), weight: SwiftGraphCodableTests_Edge(weight: 533))
+        result.addEdge(from: vertexWithName("Kansas City"), to: vertexWithName("New York"), weight: SwiftGraphCodableTests_Edge(weight: 1260))
+        result.addEdge(from: vertexWithName("Kansas City"), to: vertexWithName("Atlanta"), weight: SwiftGraphCodableTests_Edge(weight: 864))
+        result.addEdge(from: vertexWithName("Kansas City"), to: vertexWithName("Dallas"), weight: SwiftGraphCodableTests_Edge(weight: 496))
+        result.addEdge(from: vertexWithName("Chicago"), to: vertexWithName("Boston"), weight: SwiftGraphCodableTests_Edge(weight: 983))
+        result.addEdge(from: vertexWithName("Chicago"), to: vertexWithName("New York"), weight: SwiftGraphCodableTests_Edge(weight: 787))
+        result.addEdge(from: vertexWithName("Boston"), to: vertexWithName("New York"), weight: SwiftGraphCodableTests_Edge(weight: 214))
+        result.addEdge(from: vertexWithName("Atlanta"), to: vertexWithName("New York"), weight: SwiftGraphCodableTests_Edge(weight: 888))
+        result.addEdge(from: vertexWithName("Atlanta"), to: vertexWithName("Dallas"), weight: SwiftGraphCodableTests_Edge(weight: 781))
+        result.addEdge(from: vertexWithName("Atlanta"), to: vertexWithName("Houston"), weight: SwiftGraphCodableTests_Edge(weight: 810))
+        result.addEdge(from: vertexWithName("Atlanta"), to: vertexWithName("Miami"), weight: SwiftGraphCodableTests_Edge(weight: 661))
+        result.addEdge(from: vertexWithName("Houston"), to: vertexWithName("Miami"), weight: SwiftGraphCodableTests_Edge(weight: 1187))
+        result.addEdge(from: vertexWithName("Houston"), to: vertexWithName("Dallas"), weight: SwiftGraphCodableTests_Edge(weight: 239))
+        
+        return result
+    }
+    
+    func cityGraphJSONString() -> String {
+        return """
+{"edges":[[[{"u":0,"directed":false,"weight":{"weight":2097},"v":5},{"u":0,"directed":false,"weight":{"weight":1331},"v":3},{"u":0,"directed":false,"weight":{"weight":807},"v":1}]],[[{"u":1,"directed":false,"weight":{"weight":807},"v":0},{"u":1,"directed":false,"weight":{"weight":1267},"v":3},{"u":1,"directed":false,"weight":{"weight":381},"v":2}]],[[{"u":2,"directed":false,"weight":{"weight":381},"v":1},{"u":2,"directed":false,"weight":{"weight":1015},"v":3},{"u":2,"directed":false,"weight":{"weight":1663},"v":4},{"u":2,"directed":false,"weight":{"weight":1435},"v":10}]],[[{"u":3,"directed":false,"weight":{"weight":1331},"v":0},{"u":3,"directed":false,"weight":{"weight":1267},"v":1},{"u":3,"directed":false,"weight":{"weight":1015},"v":2},{"u":3,"directed":false,"weight":{"weight":1003},"v":5},{"u":3,"directed":false,"weight":{"weight":599},"v":4}]],[[{"u":4,"directed":false,"weight":{"weight":1663},"v":2},{"u":4,"directed":false,"weight":{"weight":599},"v":3},{"u":4,"directed":false,"weight":{"weight":533},"v":5},{"u":4,"directed":false,"weight":{"weight":1260},"v":7},{"u":4,"directed":false,"weight":{"weight":864},"v":8},{"u":4,"directed":false,"weight":{"weight":496},"v":10}]],[[{"u":5,"directed":false,"weight":{"weight":2097},"v":0},{"u":5,"directed":false,"weight":{"weight":1003},"v":3},{"u":5,"directed":false,"weight":{"weight":533},"v":4},{"u":5,"directed":false,"weight":{"weight":983},"v":6},{"u":5,"directed":false,"weight":{"weight":787},"v":7}]],[[{"u":6,"directed":false,"weight":{"weight":983},"v":5},{"u":6,"directed":false,"weight":{"weight":214},"v":7}]],[[{"u":7,"directed":false,"weight":{"weight":1260},"v":4},{"u":7,"directed":false,"weight":{"weight":787},"v":5},{"u":7,"directed":false,"weight":{"weight":214},"v":6},{"u":7,"directed":false,"weight":{"weight":888},"v":8}]],[[{"u":8,"directed":false,"weight":{"weight":864},"v":4},{"u":8,"directed":false,"weight":{"weight":888},"v":7},{"u":8,"directed":false,"weight":{"weight":781},"v":10},{"u":8,"directed":false,"weight":{"weight":810},"v":11},{"u":8,"directed":false,"weight":{"weight":661},"v":9}]],[[{"u":9,"directed":false,"weight":{"weight":661},"v":8},{"u":9,"directed":false,"weight":{"weight":1187},"v":11}]],[[{"u":10,"directed":false,"weight":{"weight":1435},"v":2},{"u":10,"directed":false,"weight":{"weight":496},"v":4},{"u":10,"directed":false,"weight":{"weight":781},"v":8},{"u":10,"directed":false,"weight":{"weight":239},"v":11}]],[[{"u":11,"directed":false,"weight":{"weight":810},"v":8},{"u":11,"directed":false,"weight":{"weight":1187},"v":9},{"u":11,"directed":false,"weight":{"weight":239},"v":10}]]],"vertices":[{"int":0,"string":"Seattle"},{"int":1,"string":"San Francisco"},{"int":2,"string":"Los Angeles"},{"int":3,"string":"Denver"},{"int":4,"string":"Kansas City"},{"int":5,"string":"Chicago"},{"int":6,"string":"Boston"},{"int":7,"string":"New York"},{"int":8,"string":"Atlanta"},{"int":9,"string":"Miami"},{"int":10,"string":"Dallas"},{"int":11,"string":"Houston"}]}
+"""
+    }
+    
+    func validateDijkstra1(cityGraph: WeightedGraph<SwiftGraphCodableTests_Vertex, SwiftGraphCodableTests_Edge>) {
+        let vertexWithName = { (name: String) -> SwiftGraphCodableTests_Vertex in
+            return cityGraph.immutableVertices.filter({ $0.string == name }).first!
+        }
+        
+        // Seattle -> Miami
+        let (distances, pathDict) = cityGraph.dijkstra(root: vertexWithName("New York"), startDistance: SwiftGraphCodableTests_Edge(weight: 0))
+        XCTAssertFalse(distances.isEmpty, "Dijkstra result set is empty.")
+        
+        //create map of distances to city names
+        var nameDistance: [SwiftGraphCodableTests_Vertex: SwiftGraphCodableTests_Edge?] = distanceArrayToVertexDict(distances: distances, graph: cityGraph)
+        if let temp = nameDistance[vertexWithName("San Francisco")] {
+            XCTAssertEqual(temp!, SwiftGraphCodableTests_Edge(weight: 3057), "San Francisco should be 3057 miles away.")
+        } else {
+            XCTFail("Failed to find distance to city in graph using Dijkstra.")
+        }
+        if let temp = nameDistance[vertexWithName("Los Angeles")] {
+            XCTAssertEqual(temp!, SwiftGraphCodableTests_Edge(weight: 2805), "Los Angeles should be 2805 miles away.")
+        } else {
+            XCTFail("Failed to find distance to city in graph using Dijkstra.")
+        }
+        if let temp = nameDistance[vertexWithName("Seattle")] {
+            XCTAssertEqual(temp!, SwiftGraphCodableTests_Edge(weight: 2884), "Seattle should be 2884 miles away.")
+        } else {
+            XCTFail("Failed to find distance to city in graph using Dijkstra.")
+        }
+        if let temp = nameDistance[vertexWithName("Denver")] {
+            XCTAssertEqual(temp!, SwiftGraphCodableTests_Edge(weight: 1790), "Denver should be 1790 miles away.")
+        } else {
+            XCTFail("Failed to find distance to city in graph using Dijkstra.")
+        }
+        if let temp = nameDistance[vertexWithName("Kansas City")] {
+            XCTAssertEqual(temp!, SwiftGraphCodableTests_Edge(weight: 1260), "Kansas City should be 1260 miles away.")
+        } else {
+            XCTFail("Failed to find distance to city in graph using Dijkstra.")
+        }
+        if let temp = nameDistance[vertexWithName("Chicago")] {
+            XCTAssertEqual(temp!, SwiftGraphCodableTests_Edge(weight: 787), "Chicago should be 787 miles away.")
+        } else {
+            XCTFail("Failed to find distance to city in graph using Dijkstra.")
+        }
+        if let temp = nameDistance[vertexWithName("Boston")] {
+            XCTAssertEqual(temp!, SwiftGraphCodableTests_Edge(weight: 214), "Boston should be 214 miles away.")
+        } else {
+            XCTFail("Failed to find distance to city in graph using Dijkstra.")
+        }
+        if let temp = nameDistance[vertexWithName("Atlanta")] {
+            XCTAssertEqual(temp!, SwiftGraphCodableTests_Edge(weight: 888), "Atlanta should be 888 miles away.")
+        } else {
+            XCTFail("Failed to find distance to city in graph using Dijkstra.")
+        }
+        if let temp = nameDistance[vertexWithName("Miami")] {
+            XCTAssertEqual(temp!, SwiftGraphCodableTests_Edge(weight: 1549), "Miami should be 1549 miles away.")
+        } else {
+            XCTFail("Failed to find distance to city in graph using Dijkstra.")
+        }
+        if let temp = nameDistance[vertexWithName("Dallas")] {
+            XCTAssertEqual(temp!, SwiftGraphCodableTests_Edge(weight: 1669), "Dallas should be 1669 miles away.")
+        } else {
+            XCTFail("Failed to find distance to city in graph using Dijkstra.")
+        }
+        if let temp = nameDistance[vertexWithName("Houston")] {
+            XCTAssertEqual(temp!, SwiftGraphCodableTests_Edge(weight: 1698), "Houston should be 1698 miles away.")
+        } else {
+            XCTFail("Failed to find distance to city in graph using Dijkstra.")
+        }
+        for (key, value) in nameDistance {
+            print("\(key) : \(String(describing: value))")
+        }
+        
+        //path between New York and San Francisco
+        let path: [WeightedEdge<SwiftGraphCodableTests_Edge>] = pathDictToPath(from: cityGraph.indexOfVertex(vertexWithName("New York"))!, to: cityGraph.indexOfVertex(vertexWithName("San Francisco"))!, pathDict: pathDict)
+        let stops: [SwiftGraphCodableTests_Vertex] = edgesToVertices(edges: path, graph: cityGraph)
+        print("\(stops))")
+        XCTAssertEqual(stops, [
+            SwiftGraphCodableTests_Vertex(int: 7, string: "New York"),
+            SwiftGraphCodableTests_Vertex(int: 5, string: "Chicago"),
+            SwiftGraphCodableTests_Vertex(int: 3, string: "Denver"),
+            SwiftGraphCodableTests_Vertex(int: 1, string: "San Francisco")
+            ], "Atlanta should be 888 miles away.")
+        //println(edgesToVertices(result, cityGraph))  // not sure why description not called by println
+    }
+    
+    func testComplexWeightedEncodable() {
+        let g = self.cityGraph()
+        self.validateDijkstra1(cityGraph: g)
+        
+        let jsonData: Data
+        do {
+            jsonData = try JSONEncoder().encode(g)
+        } catch {
+            XCTFail("JSONEncoder().encode(g) threw: \(error)")
+            return
+        }
+        let jsonString = String(data: jsonData, encoding: .utf8)
+        // TODO: we should probably compare reparsed Dictionarys to be safe
+        XCTAssertEqual(jsonString, self.cityGraphJSONString())
+    }
+    
+    func testComplexWeightedDecodable() {
+        guard let jsonData = self.cityGraphJSONString().data(using: .utf8) else {
+            XCTFail("Unable to serialize expected JSON string into Data")
+            return
+        }
+        
+        let g: WeightedGraph<SwiftGraphCodableTests_Vertex, SwiftGraphCodableTests_Edge>
+        do {
+            g = try JSONDecoder().decode(WeightedGraph<SwiftGraphCodableTests_Vertex, SwiftGraphCodableTests_Edge>.self, from: jsonData)
+        } catch {
+            XCTFail("JSONDecoder().decode(WeightedGraph<SwiftGraphCodableTests_Vertex, SwiftGraphCodableTests_Edge>.self, from: jsonData) threw: \(error)")
+            return
+        }
+        self.validateDijkstra1(cityGraph: g)
+        //        XCTAssertEqual(g, self.cityGraph())
+    }
+}


### PR DESCRIPTION
Initial commit! Pushing to show progress, potentially get insight from others.

It would be great to see if we could implement it such that the generic classes' types didn't require conforming to `Codable` and that it would only be necessary when wanted to the classes as `Codable`. However Swift's `init` methods as well as `where` clauses have limitations with extensions that I haven't figured out how to work the way I am hoping.

Also tests need cleaning and elaboration.