### PR TITLE
Fix ambiguous use of 'addEdge(from:to:directed:)' on Int graphs

### DIFF
--- a/Sources/SwiftGraph/UniqueElementsGraph.swift
+++ b/Sources/SwiftGraph/UniqueElementsGraph.swift
@@ -56,7 +56,7 @@ open class UniqueElementsGraph<V: Equatable>: UnweightedGraph<V> {
     /// - parameter from: The starting vertex's index.
     /// - parameter to: The ending vertex's index.
     /// - parameter directed: Is the edge directed? (default `false`)
-    public override func addEdge(from u: Int, to v: Int, directed: Bool = false) {
+    public override func addEdge(fromIndex u: Int, toIndex v: Int, directed: Bool = false) {
         if !edgeExists(from: u, to: v) {
             addEdge(UnweightedEdge(u: u, v: v))
             if !directed && !edgeExists(from: v, to: u) {
@@ -72,7 +72,7 @@ open class UniqueElementsGraph<V: Equatable>: UnweightedGraph<V> {
     /// - parameter directed: Is the edge directed? (default `false`)
     public override func addEdge(from: V, to: V, directed: Bool = false) {
         if let u = indexOfVertex(from), let v = indexOfVertex(to) {
-            addEdge(from: u, to: v, directed: directed)
+            addEdge(fromIndex: u, toIndex: v, directed: directed)
         }
     }
 }

--- a/Sources/SwiftGraph/UnweightedGraph.swift
+++ b/Sources/SwiftGraph/UnweightedGraph.swift
@@ -84,10 +84,10 @@ open class UnweightedGraph<V: Equatable>: Graph {
     /// - parameter from: The starting vertex's index.
     /// - parameter to: The ending vertex's index.
     /// - parameter directed: Is the edge directed? (default `false`)
-    public func addEdge(from: Int, to: Int, directed: Bool = false) {
-        addEdge(UnweightedEdge(u: from, v: to))
+    public func addEdge(fromIndex: Int, toIndex: Int, directed: Bool = false) {
+        addEdge(UnweightedEdge(u: fromIndex, v: toIndex))
         if !directed {
-            addEdge(UnweightedEdge(u: to, v: from))
+            addEdge(UnweightedEdge(u: toIndex, v: fromIndex))
         }
         
     }

--- a/Sources/SwiftGraph/WeightedGraph.swift
+++ b/Sources/SwiftGraph/WeightedGraph.swift
@@ -48,10 +48,10 @@ open class WeightedGraph<V: Equatable, W: Comparable & Numeric & Codable>: Graph
     /// - parameter to: The ending vertex's index.
     /// - parameter directed: Is the edge directed? (default false)
     /// - parameter weight: the Weight of the edge to add.
-    public func addEdge(from: Int, to: Int, weight:W, directed: Bool = false) {
-        addEdge(WeightedEdge<W>(u: from, v: to, weight: weight))
+    public func addEdge(fromIndex: Int, toIndex: Int, weight:W, directed: Bool = false) {
+        addEdge(WeightedEdge<W>(u: fromIndex, v: toIndex, weight: weight))
         if !directed {
-            addEdge(WeightedEdge<W>(u: to, v: from, weight: weight))
+            addEdge(WeightedEdge<W>(u: toIndex, v: fromIndex, weight: weight))
         }
     }
     
@@ -63,7 +63,7 @@ open class WeightedGraph<V: Equatable, W: Comparable & Numeric & Codable>: Graph
     /// - parameter weight: the Weight of the edge to add.
     public func addEdge(from: V, to: V, weight: W, directed: Bool = false) {
         if let u = indexOfVertex(from), let v = indexOfVertex(to) {
-            addEdge(from: u, to: v, weight: weight, directed: directed)
+            addEdge(fromIndex: u, toIndex: v, weight: weight, directed: directed)
         }
     }
     

--- a/Tests/SwiftGraphTests/CycleTests.swift
+++ b/Tests/SwiftGraphTests/CycleTests.swift
@@ -29,7 +29,7 @@ class CycleTests: XCTestCase {
         // setup a graph with 5 fully connected vertices
         for from in 0..<fullyConnected.vertexCount {
             for to in (from + 1)..<fullyConnected.vertexCount {
-                fullyConnected.addEdge(from: from, to: to)
+                fullyConnected.addEdge(fromIndex: from, toIndex: to)
             }
         }
         


### PR DESCRIPTION
Both addEdge methods have the same signature when the Vertex type parameter is Int. 
Sadly this can only be fixed with an api-breaking change. I have renamed the parameters of the method adding an edge by index.