### PR TITLE
Improve performance for constructors

### DIFF
--- a/Sources/SwiftGraph/Union.swift
+++ b/Sources/SwiftGraph/Union.swift
@@ -37,7 +37,7 @@ public extension UniqueElementsGraph {
 
         // We know vertices in lhs are unique, so we call Graph.addVertex to avoid the uniqueness check of UniqueElementsGraph.addVertex.
         for vertex in firstGraph.vertices {
-            _ = super.addVertex(vertex)
+            _ = addVertex(vertex)
         }
 
         // When vertices are removed from Graph, edges might mutate,

--- a/Sources/SwiftGraph/UniqueElementsGraph.swift
+++ b/Sources/SwiftGraph/UniqueElementsGraph.swift
@@ -104,6 +104,9 @@ extension UniqueElementsGraph {
         self.init(vertices: path)
 
         guard path.count >= 2 else {
+            if let v = path.first {
+                _ = addVertex(v)
+            }
             return
         }
 
@@ -131,6 +134,10 @@ extension UniqueElementsGraph {
         self.init(vertices: cycle)
 
         guard cycle.count >= 2 else {
+            if let v = cycle.first {
+                let index = addVertex(v)
+                addEdge(fromIndex: index, toIndex: index)
+            }
             return
         }
 

--- a/Sources/SwiftGraph/UniqueElementsGraph.swift
+++ b/Sources/SwiftGraph/UniqueElementsGraph.swift
@@ -30,6 +30,55 @@ open class UniqueElementsGraph<V: Equatable>: UnweightedGraph<V> {
             _ = self.addVertex(vertex) // make sure to call our version
         }
     }
+
+    /// Initialize an UnweightedGraph consisting of path.
+    ///
+    /// The resulting graph has the vertices in path and an edge between
+    /// each pair of consecutive vertices in path.
+    ///
+    /// If path is an empty array, the resulting graph is the empty graph.
+    /// If path is an array with a single vertex, the resulting graph has that vertex and no edges.
+    ///
+    /// - Parameters:
+    ///   - path: An array of vertices representing a path.
+    ///   - directed: If false, undirected edges are created.
+    ///               If true, edges are directed from vertex i to vertex i+1 in path.
+    ///               Default is false.
+    public convenience init(withPath path: [V], directed: Bool = false) {
+        self.init(vertices: path)
+
+        guard path.count >= 2 else {
+            return
+        }
+
+        for i in 0..<path.count - 1 {
+            let vertices = path[i...i+1]
+            self.addEdge(from: vertices.first!, to: vertices.last!, directed: directed)
+        }
+    }
+
+    /// Initialize an UnweightedGraph consisting of cycle.
+    ///
+    /// The resulting graph has the vertices in cycle and an edge between
+    /// each pair of consecutive vertices in cycle,
+    /// plus an edge between the last and the first vertices.
+    ///
+    /// If path is an empty array, the resulting graph is the empty graph.
+    /// If path is an array with a single vertex, the resulting graph has the vertex
+    /// and a single edge to itself if directed is true.
+    /// If directed is false the resulting graph has the vertex and two edges to itself.
+    ///
+    /// - Parameters:
+    ///   - cycle: An array of vertices representing a cycle.
+    ///   - directed: If false, undirected edges are created.
+    ///               If true, edges are directed from vertex i to vertex i+1 in cycle.
+    ///               Default is false.
+    public convenience init(withCycle cycle: [V], directed: Bool = false) {
+        self.init(withPath: cycle, directed: directed)
+        if cycle.count > 0 {
+            self.addEdge(from: cycle.last!, to: cycle.first!, directed: directed)
+        }
+    }
     
     /// Add a vertex to the graph if no equal vertex already belongs to the Graph. O(n)
     ///

--- a/Sources/SwiftGraph/UniqueElementsGraph.swift
+++ b/Sources/SwiftGraph/UniqueElementsGraph.swift
@@ -17,15 +17,15 @@
 //  limitations under the License.
 
 /// A subclass of UnweightedGraph that ensures there are no pairs of equal vertices and no repeated edges.
-open class UniqueElementsGraph<V: Equatable>: UnweightedGraph<V> {
+open class UniqueElementsGraph<V: Equatable>: Graph {
+    public var vertices: [V] = [V]()
+    public var edges: [[UnweightedEdge]] = [[UnweightedEdge]]() //adjacency lists
 
-    public override init() {
-        super.init()
+    public init() {
     }
 
     /// Init the Graph with vertices, but removes duplicates. O(n^2)
-    public override init(vertices: [V]) {
-        super.init()
+    public init(vertices: [V]) {
         for vertex in vertices {
             _ = self.addVertex(vertex) // make sure to call our version
         }
@@ -88,13 +88,15 @@ open class UniqueElementsGraph<V: Equatable>: UnweightedGraph<V> {
         if let equalVertexIndex = indexOfVertex(v) {
             return equalVertexIndex
         }
-        return super.addVertex(v)
+        vertices.append(v)
+        edges.append([E]())
+        return vertices.count - 1
     }
 
     /// Only allow the edge to be added once
     ///
     /// - parameter e: The edge to add.
-    public func addEdge(_ e: E) {
+    public func addEdge(_ e: UnweightedEdge) {
         if !edgeExists(from: e.u, to: e.v) {
             edges[e.u].append(e)
         }
@@ -105,7 +107,7 @@ open class UniqueElementsGraph<V: Equatable>: UnweightedGraph<V> {
     /// - parameter from: The starting vertex's index.
     /// - parameter to: The ending vertex's index.
     /// - parameter directed: Is the edge directed? (default `false`)
-    public override func addEdge(fromIndex u: Int, toIndex v: Int, directed: Bool = false) {
+    public func addEdge(fromIndex u: Int, toIndex v: Int, directed: Bool = false) {
         if !edgeExists(from: u, to: v) {
             addEdge(UnweightedEdge(u: u, v: v))
             if !directed && !edgeExists(from: v, to: u) {
@@ -119,7 +121,7 @@ open class UniqueElementsGraph<V: Equatable>: UnweightedGraph<V> {
     /// - parameter from: The starting vertex.
     /// - parameter to: The ending vertex.
     /// - parameter directed: Is the edge directed? (default `false`)
-    public override func addEdge(from: V, to: V, directed: Bool = false) {
+    public func addEdge(from: V, to: V, directed: Bool = false) {
         if let u = indexOfVertex(from), let v = indexOfVertex(to) {
             addEdge(fromIndex: u, toIndex: v, directed: directed)
         }

--- a/Sources/SwiftGraph/UniqueElementsGraph.swift
+++ b/Sources/SwiftGraph/UniqueElementsGraph.swift
@@ -31,32 +31,6 @@ open class UniqueElementsGraph<V: Equatable>: Graph {
         }
     }
 
-    /// Initialize an UnweightedGraph consisting of path.
-    ///
-    /// The resulting graph has the vertices in path and an edge between
-    /// each pair of consecutive vertices in path.
-    ///
-    /// If path is an empty array, the resulting graph is the empty graph.
-    /// If path is an array with a single vertex, the resulting graph has that vertex and no edges.
-    ///
-    /// - Parameters:
-    ///   - path: An array of vertices representing a path.
-    ///   - directed: If false, undirected edges are created.
-    ///               If true, edges are directed from vertex i to vertex i+1 in path.
-    ///               Default is false.
-    public convenience init(withPath path: [V], directed: Bool = false) {
-        self.init(vertices: path)
-
-        guard path.count >= 2 else {
-            return
-        }
-
-        for i in 0..<path.count - 1 {
-            let vertices = path[i...i+1]
-            self.addEdge(from: vertices.first!, to: vertices.last!, directed: directed)
-        }
-    }
-
     /// Initialize an UnweightedGraph consisting of cycle.
     ///
     /// The resulting graph has the vertices in cycle and an edge between
@@ -124,6 +98,78 @@ open class UniqueElementsGraph<V: Equatable>: Graph {
     public func addEdge(from: V, to: V, directed: Bool = false) {
         if let u = indexOfVertex(from), let v = indexOfVertex(to) {
             addEdge(fromIndex: u, toIndex: v, directed: directed)
+        }
+    }
+}
+
+extension UniqueElementsGraph {
+    /// Initialize an UnweightedGraph consisting of path.
+    ///
+    /// The resulting graph has the vertices in path and an edge between
+    /// each pair of consecutive vertices in path.
+    ///
+    /// If path is an empty array, the resulting graph is the empty graph.
+    /// If path is an array with a single vertex, the resulting graph has that vertex and no edges.
+    ///
+    /// - Parameters:
+    ///   - path: An array of vertices representing a path.
+    ///   - directed: If false, undirected edges are created.
+    ///               If true, edges are directed from vertex i to vertex i+1 in path.
+    ///               Default is false.
+    public convenience init(withPath path: [V], directed: Bool = false) {
+        self.init(vertices: path)
+
+        guard path.count >= 2 else {
+            return
+        }
+
+        for i in 0..<path.count - 1 {
+            let vertices = path[i...i+1]
+            self.addEdge(from: vertices.first!, to: vertices.last!, directed: directed)
+        }
+    }
+
+}
+
+extension UniqueElementsGraph where V: Hashable {
+    /// Initialize an UnweightedGraph consisting of path.
+    ///
+    /// The resulting graph has the vertices in path and an edge between
+    /// each pair of consecutive vertices in path.
+    ///
+    /// If path is an empty array, the resulting graph is the empty graph.
+    /// If path is an array with a single vertex, the resulting graph has that vertex and no edges.
+    ///
+    /// - Parameters:
+    ///   - path: An array of vertices representing a path.
+    ///   - directed: If false, undirected edges are created.
+    ///               If true, edges are directed from vertex i to vertex i+1 in path.
+    ///               Default is false.
+    public convenience init(withPath path: [V], directed: Bool = false) {
+        self.init()
+
+        guard path.count >= 2 else {
+            if let v = path.first {
+                _ = addVertex(v)
+            }
+            return
+        }
+
+        var indices: [Int] = []
+        var indexForVertex: Dictionary<V, Int> = [:]
+
+        for v in path {
+            if let index = indexForVertex[v] {
+                indices.append(index)
+            } else {
+                let index = addVertex(v)
+                indices.append(index)
+                indexForVertex[v] = index
+            }
+        }
+
+        for i in 0..<path.count - 1 {
+            addEdge(fromIndex: indices[i], toIndex: indices[i+1], directed: directed)
         }
     }
 }

--- a/Sources/SwiftGraph/UniqueElementsGraph.swift
+++ b/Sources/SwiftGraph/UniqueElementsGraph.swift
@@ -123,9 +123,9 @@ extension UniqueElementsGraph {
             return
         }
 
+        let indices = path.map({ indexOfVertex($0)! })
         for i in 0..<path.count - 1 {
-            let vertices = path[i...i+1]
-            self.addEdge(from: vertices.first!, to: vertices.last!, directed: directed)
+            addEdge(fromIndex: indices[i], toIndex: indices[i+1], directed: directed)
         }
     }
 

--- a/Sources/SwiftGraph/UnweightedGraph.swift
+++ b/Sources/SwiftGraph/UnweightedGraph.swift
@@ -51,8 +51,7 @@ open class UnweightedGraph<V: Equatable>: Graph {
         }
 
         for i in 0..<path.count - 1 {
-            let vertices = path[i...i+1]
-            self.addEdge(from: vertices.first!, to: vertices.last!, directed: directed)
+            self.addEdge(fromIndex: i, toIndex: i+1, directed: directed)
         }
     }
 
@@ -75,7 +74,7 @@ open class UnweightedGraph<V: Equatable>: Graph {
     public convenience init(withCycle cycle: [V], directed: Bool = false) {
         self.init(withPath: cycle, directed: directed)
         if cycle.count > 0 {
-            self.addEdge(from: cycle.last!, to: cycle.first!, directed: directed)
+            self.addEdge(fromIndex: cycle.count-1, toIndex: 0, directed: directed)
         }
     }
     

--- a/SwiftGraph.xcodeproj/project.pbxproj
+++ b/SwiftGraph.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		B5EACB1D2172315E00E527BD /* SwiftGraph.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7985B8FB1E5A4FB800C100E7 /* SwiftGraph.framework */; };
 		B5EACB292172336900E527BD /* SearchPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DD6DA42171EEE1007EFF44 /* SearchPerformanceTests.swift */; };
 		B5EF143121791009008FCC5C /* UniqueElementsGraphInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EF143021791009008FCC5C /* UniqueElementsGraphInitTests.swift */; };
+		B5EF143321791348008FCC5C /* UniqueElementsGraphHashableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EF143221791348008FCC5C /* UniqueElementsGraphHashableTests.swift */; };
+		B5EF1437217913F1008FCC5C /* EquatableTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EF1436217913F1008FCC5C /* EquatableTypes.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -129,6 +131,8 @@
 		B5DD6DA42171EEE1007EFF44 /* SearchPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPerformanceTests.swift; sourceTree = "<group>"; };
 		B5EACB222172315E00E527BD /* SwiftGraphPerformanceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftGraphPerformanceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5EF143021791009008FCC5C /* UniqueElementsGraphInitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniqueElementsGraphInitTests.swift; sourceTree = "<group>"; };
+		B5EF143221791348008FCC5C /* UniqueElementsGraphHashableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniqueElementsGraphHashableTests.swift; sourceTree = "<group>"; };
+		B5EF1436217913F1008FCC5C /* EquatableTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableTypes.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -262,6 +266,7 @@
 		7985B9091E5A4FB900C100E7 /* SwiftGraphTests */ = {
 			isa = PBXGroup;
 			children = (
+				B5EF1435217913E0008FCC5C /* Utils */,
 				B54FDA6F2172A30600057C51 /* Constructors */,
 				B523F2E82094F0A1006587ED /* UniqueElementsGraph */,
 				557F55E91F8AB247002AF0BF /* Info.plist */,
@@ -283,8 +288,9 @@
 			isa = PBXGroup;
 			children = (
 				B5D229BD207BF36900151820 /* UniqueElementsGraphTests.swift */,
-				B523F2E92094F0E2006587ED /* UniqueElementsGraphHashableInitTests.swift */,
+				B5EF143221791348008FCC5C /* UniqueElementsGraphHashableTests.swift */,
 				B5EF143021791009008FCC5C /* UniqueElementsGraphInitTests.swift */,
+				B523F2E92094F0E2006587ED /* UniqueElementsGraphHashableInitTests.swift */,
 			);
 			path = UniqueElementsGraph;
 			sourceTree = "<group>";
@@ -313,6 +319,14 @@
 			);
 			name = SwiftGraphPerformanceTests;
 			path = Tests/SwiftGraphPerformanceTests;
+			sourceTree = "<group>";
+		};
+		B5EF1435217913E0008FCC5C /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				B5EF1436217913F1008FCC5C /* EquatableTypes.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -525,8 +539,10 @@
 				B52ABD39208955BD00FBF10C /* UnionTests.swift in Sources */,
 				55E784281ED2971E003899D0 /* MSTTests.swift in Sources */,
 				B5100A4D208B97AA00C7A73A /* UnweightedGraphTests.swift in Sources */,
+				B5EF1437217913F1008FCC5C /* EquatableTypes.swift in Sources */,
 				7985B91D1E5A4FCB00C100E7 /* DijkstraGraphTests.swift in Sources */,
 				7985B91F1E5A4FCB00C100E7 /* SwiftGraphSortTests.swift in Sources */,
+				B5EF143321791348008FCC5C /* UniqueElementsGraphHashableTests.swift in Sources */,
 				55F5EA5B2151E33100DFC301 /* SwiftGraphCodableTests.swift in Sources */,
 				B523F2EA2094F0E2006587ED /* UniqueElementsGraphHashableInitTests.swift in Sources */,
 				B5EF143121791009008FCC5C /* UniqueElementsGraphInitTests.swift in Sources */,

--- a/SwiftGraph.xcodeproj/project.pbxproj
+++ b/SwiftGraph.xcodeproj/project.pbxproj
@@ -36,7 +36,7 @@
 		7985B92B1E5A503200C100E7 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5589B47A1C0E75A700D6664E /* Queue.swift */; };
 		B5100A4D208B97AA00C7A73A /* UnweightedGraphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5100A4B208B97A800C7A73A /* UnweightedGraphTests.swift */; };
 		B51B460B2083E14200CD0463 /* Union.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51B460A2083E14200CD0463 /* Union.swift */; };
-		B523F2EA2094F0E2006587ED /* UniqueElementsGraphInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B523F2E92094F0E2006587ED /* UniqueElementsGraphInitTests.swift */; };
+		B523F2EA2094F0E2006587ED /* UniqueElementsGraphHashableInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B523F2E92094F0E2006587ED /* UniqueElementsGraphHashableInitTests.swift */; };
 		B52ABD39208955BD00FBF10C /* UnionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52ABD37208955B500FBF10C /* UnionTests.swift */; };
 		B54FDA6E21729EFF00057C51 /* Constructors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54FDA6D21729EFF00057C51 /* Constructors.swift */; };
 		B54FDA712172A34D00057C51 /* ConstructorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54FDA702172A34D00057C51 /* ConstructorsTests.swift */; };
@@ -45,6 +45,7 @@
 		B5D229BF207BF3A800151820 /* UniqueElementsGraphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D229BD207BF36900151820 /* UniqueElementsGraphTests.swift */; };
 		B5EACB1D2172315E00E527BD /* SwiftGraph.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7985B8FB1E5A4FB800C100E7 /* SwiftGraph.framework */; };
 		B5EACB292172336900E527BD /* SearchPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DD6DA42171EEE1007EFF44 /* SearchPerformanceTests.swift */; };
+		B5EF143121791009008FCC5C /* UniqueElementsGraphInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EF143021791009008FCC5C /* UniqueElementsGraphInitTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -118,7 +119,7 @@
 		7985B91C1E5A4FCB00C100E7 /* SwiftGraphTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftGraphTests.swift; sourceTree = "<group>"; };
 		B5100A4B208B97A800C7A73A /* UnweightedGraphTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnweightedGraphTests.swift; sourceTree = "<group>"; };
 		B51B460A2083E14200CD0463 /* Union.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Union.swift; path = ../Sources/SwiftGraph/Union.swift; sourceTree = "<group>"; };
-		B523F2E92094F0E2006587ED /* UniqueElementsGraphInitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniqueElementsGraphInitTests.swift; sourceTree = "<group>"; };
+		B523F2E92094F0E2006587ED /* UniqueElementsGraphHashableInitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniqueElementsGraphHashableInitTests.swift; sourceTree = "<group>"; };
 		B52ABD37208955B500FBF10C /* UnionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnionTests.swift; sourceTree = "<group>"; };
 		B54FDA6D21729EFF00057C51 /* Constructors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Constructors.swift; path = ../Sources/SwiftGraph/Constructors.swift; sourceTree = "<group>"; };
 		B54FDA702172A34D00057C51 /* ConstructorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstructorsTests.swift; sourceTree = "<group>"; };
@@ -127,6 +128,7 @@
 		B5D229BD207BF36900151820 /* UniqueElementsGraphTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniqueElementsGraphTests.swift; sourceTree = "<group>"; };
 		B5DD6DA42171EEE1007EFF44 /* SearchPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPerformanceTests.swift; sourceTree = "<group>"; };
 		B5EACB222172315E00E527BD /* SwiftGraphPerformanceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftGraphPerformanceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B5EF143021791009008FCC5C /* UniqueElementsGraphInitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniqueElementsGraphInitTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -281,7 +283,8 @@
 			isa = PBXGroup;
 			children = (
 				B5D229BD207BF36900151820 /* UniqueElementsGraphTests.swift */,
-				B523F2E92094F0E2006587ED /* UniqueElementsGraphInitTests.swift */,
+				B523F2E92094F0E2006587ED /* UniqueElementsGraphHashableInitTests.swift */,
+				B5EF143021791009008FCC5C /* UniqueElementsGraphInitTests.swift */,
 			);
 			path = UniqueElementsGraph;
 			sourceTree = "<group>";
@@ -525,7 +528,8 @@
 				7985B91D1E5A4FCB00C100E7 /* DijkstraGraphTests.swift in Sources */,
 				7985B91F1E5A4FCB00C100E7 /* SwiftGraphSortTests.swift in Sources */,
 				55F5EA5B2151E33100DFC301 /* SwiftGraphCodableTests.swift in Sources */,
-				B523F2EA2094F0E2006587ED /* UniqueElementsGraphInitTests.swift in Sources */,
+				B523F2EA2094F0E2006587ED /* UniqueElementsGraphHashableInitTests.swift in Sources */,
+				B5EF143121791009008FCC5C /* UniqueElementsGraphInitTests.swift in Sources */,
 				B54FDA712172A34D00057C51 /* ConstructorsTests.swift in Sources */,
 				B5D229BF207BF3A800151820 /* UniqueElementsGraphTests.swift in Sources */,
 			);

--- a/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/94D648AC-76B2-4B8F-A1FF-3A34FAC1AF9B.plist
+++ b/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/94D648AC-76B2-4B8F-A1FF-3A34FAC1AF9B.plist
@@ -61,7 +61,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>1.5</real>
+					<real>1.07</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -71,7 +71,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>1.5352</real>
+					<real>0.516</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/94D648AC-76B2-4B8F-A1FF-3A34FAC1AF9B.plist
+++ b/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/94D648AC-76B2-4B8F-A1FF-3A34FAC1AF9B.plist
@@ -31,7 +31,17 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>1.5</real>
+					<real>0.515</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testCycleUniqueElementsHashableConstructor()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>1.0671</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/94D648AC-76B2-4B8F-A1FF-3A34FAC1AF9B.plist
+++ b/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/94D648AC-76B2-4B8F-A1FF-3A34FAC1AF9B.plist
@@ -41,7 +41,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>1</real>
+					<real>0.21</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -71,7 +71,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.998</real>
+					<real>0.208</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/94D648AC-76B2-4B8F-A1FF-3A34FAC1AF9B.plist
+++ b/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/94D648AC-76B2-4B8F-A1FF-3A34FAC1AF9B.plist
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>ConstructorsPerformanceTests</key>
+		<dict>
+			<key>testCompleteGraphConstructor()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>2.45</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testCycleGraphConstructor()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>1.0632</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testCycleUniqueElementsGraphConstructor()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>1.5</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testCycleUnweightedGraphConstructor()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>1</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testPathGraphConstructor()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>1.03</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testPathUniqueElementsGraphConstructor()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>1.5</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testPathUnweightedGraphConstructor()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.998</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testStarGraphConstructor()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>2.18</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/94D648AC-76B2-4B8F-A1FF-3A34FAC1AF9B.plist
+++ b/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/94D648AC-76B2-4B8F-A1FF-3A34FAC1AF9B.plist
@@ -51,7 +51,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.21</real>
+					<real>2.08</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -91,7 +91,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.208</real>
+					<real>2.07</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/94D648AC-76B2-4B8F-A1FF-3A34FAC1AF9B.plist
+++ b/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/94D648AC-76B2-4B8F-A1FF-3A34FAC1AF9B.plist
@@ -66,6 +66,16 @@
 					<string>Local Baseline</string>
 				</dict>
 			</dict>
+			<key>testPathUniqueElementsGraphHashableConstructor()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>1.5352</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
 			<key>testPathUnweightedGraphConstructor()</key>
 			<dict>
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>

--- a/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/Info.plist
+++ b/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/Info.plist
@@ -4,6 +4,30 @@
 <dict>
 	<key>runDestinationsByUUID</key>
 	<dict>
+		<key>94D648AC-76B2-4B8F-A1FF-3A34FAC1AF9B</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Intel Core i5</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2300</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>modelCode</key>
+				<string>MacBookPro14,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>2</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+		</dict>
 		<key>A8BA0D0E-6C5D-4885-B097-4A07B03D02BF</key>
 		<dict>
 			<key>localComputer</key>

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,21 +1,10 @@
 import XCTest
-@testable import SwiftGraphTests
-@testable import SwiftGraphPerformanceTests
 
-XCTMain([
-    testCase(DijkstraGraphTests.allTests),
-    testCase(MSTTests.allTests),
-    testCase(SwiftGraphSearchTests.allTests),
-    testCase(SwiftGraphSortTests.allTests),
-    testCase(SwiftGraphTests.allTests),
-    testCase(UnweightedGraphTests.allTests),
-    testCase(CycleTests.allTests),
-    testCase(UniqueElementsGraphTests.allTests),
-    testCase(UniqueElementsGraphInitTests.allTests),
-    testCase(UnionTests.allTests),
-    testCase(SwiftGraphCodableTests.allTests),
-    testCase(ConstructorsTests.allTests),
+import SwiftGraphPerformanceTests
+import SwiftGraphTests
 
-    testCase(SearchPerformanceTests.allTests),
-    testCase(ConstructorsPerformanceTests.allTests),
-])
+var tests = [XCTestCaseEntry]()
+tests += SwiftGraphPerformanceTests.__allTests()
+tests += SwiftGraphTests.__allTests()
+
+XCTMain(tests)

--- a/Tests/SwiftGraphPerformanceTests/ConstructorsPerformanceTests.swift
+++ b/Tests/SwiftGraphPerformanceTests/ConstructorsPerformanceTests.swift
@@ -20,6 +20,30 @@ import XCTest
 @testable import SwiftGraph
 
 class ConstructorsPerformanceTests: XCTestCase {
+    func testPathUnweightedGraphConstructor() {
+        self.measure {
+            _ = UnweightedGraph(withPath: Array(1...2999))
+        }
+    }
+
+    func testCycleUnweightedGraphConstructor() {
+        self.measure {
+            _ = UnweightedGraph(withCycle: Array(1...2999))
+        }
+    }
+
+    func testPathUniqueElementsGraphConstructor() {
+        self.measure {
+            _ = UniqueElementsGraph(withPath: Array(1...2999))
+        }
+    }
+
+    func testCycleUniqueElementsGraphConstructor() {
+        self.measure {
+            _ = UniqueElementsGraph(withCycle: Array(1...2999))
+        }
+    }
+
     func testStarGraphConstructor() {
         self.measure {
             _ = StarGraph.build(withCenter: 0, andLeafs: Array(1...999999))
@@ -33,6 +57,10 @@ class ConstructorsPerformanceTests: XCTestCase {
     }
 
     static var allTests = [
+        ("testPathUnweightedGraphConstructor", testPathUnweightedGraphConstructor),
+        ("testCycleUnweightedGraphConstructor", testCycleUnweightedGraphConstructor),
+        ("testPathUniqueElementsGraphConstructor", testPathUniqueElementsGraphConstructor),
+        ("testCycleUniqueElementsGraphConstructor", testCycleUniqueElementsGraphConstructor),
         ("testStarGraphConstructor", testStarGraphConstructor),
         ("testCompleteGraphConstructor", testCompleteGraphConstructor),
     ]

--- a/Tests/SwiftGraphPerformanceTests/ConstructorsPerformanceTests.swift
+++ b/Tests/SwiftGraphPerformanceTests/ConstructorsPerformanceTests.swift
@@ -20,6 +20,11 @@ import XCTest
 @testable import SwiftGraph
 
 class ConstructorsPerformanceTests: XCTestCase {
+
+    struct AnyEquatable<T: Equatable>: Equatable {
+        let value: T
+    }
+
     func testPathUnweightedGraphConstructor() {
         self.measure {
             _ = UnweightedGraph(withPath: Array(1...99999))
@@ -33,8 +38,15 @@ class ConstructorsPerformanceTests: XCTestCase {
     }
 
     func testPathUniqueElementsGraphConstructor() {
+        let array = Array(1...2999).map({ AnyEquatable(value: $0) })
         self.measure {
-            _ = UniqueElementsGraph(withPath: Array(1...2999))
+            _ = UniqueElementsGraph<AnyEquatable>(withPath: array)
+        }
+    }
+
+    func testPathUniqueElementsGraphHashableConstructor() {
+        self.measure {
+            _ = UniqueElementsGraph<Int>(withPath: Array(1...2999))
         }
     }
 

--- a/Tests/SwiftGraphPerformanceTests/ConstructorsPerformanceTests.swift
+++ b/Tests/SwiftGraphPerformanceTests/ConstructorsPerformanceTests.swift
@@ -22,13 +22,13 @@ import XCTest
 class ConstructorsPerformanceTests: XCTestCase {
     func testPathUnweightedGraphConstructor() {
         self.measure {
-            _ = UnweightedGraph(withPath: Array(1...2999))
+            _ = UnweightedGraph(withPath: Array(1...99999))
         }
     }
 
     func testCycleUnweightedGraphConstructor() {
         self.measure {
-            _ = UnweightedGraph(withCycle: Array(1...2999))
+            _ = UnweightedGraph(withCycle: Array(1...99999))
         }
     }
 

--- a/Tests/SwiftGraphPerformanceTests/ConstructorsPerformanceTests.swift
+++ b/Tests/SwiftGraphPerformanceTests/ConstructorsPerformanceTests.swift
@@ -27,13 +27,13 @@ class ConstructorsPerformanceTests: XCTestCase {
 
     func testPathUnweightedGraphConstructor() {
         self.measure {
-            _ = UnweightedGraph(withPath: Array(1...99999))
+            _ = UnweightedGraph(withPath: Array(1...999999))
         }
     }
 
     func testCycleUnweightedGraphConstructor() {
         self.measure {
-            _ = UnweightedGraph(withCycle: Array(1...99999))
+            _ = UnweightedGraph(withCycle: Array(1...999999))
         }
     }
 

--- a/Tests/SwiftGraphPerformanceTests/ConstructorsPerformanceTests.swift
+++ b/Tests/SwiftGraphPerformanceTests/ConstructorsPerformanceTests.swift
@@ -56,6 +56,13 @@ class ConstructorsPerformanceTests: XCTestCase {
         }
     }
 
+    func testCycleUniqueElementsHashableConstructor() {
+        let array = Array(1...2999).map({ AnyEquatable(value: $0) })
+        self.measure {
+            _ = UniqueElementsGraph(withCycle: array)
+        }
+    }
+
     func testStarGraphConstructor() {
         self.measure {
             _ = StarGraph.build(withCenter: 0, andLeafs: Array(1...999999))
@@ -72,7 +79,9 @@ class ConstructorsPerformanceTests: XCTestCase {
         ("testPathUnweightedGraphConstructor", testPathUnweightedGraphConstructor),
         ("testCycleUnweightedGraphConstructor", testCycleUnweightedGraphConstructor),
         ("testPathUniqueElementsGraphConstructor", testPathUniqueElementsGraphConstructor),
+        ("testPathUniqueElementsGraphHashableConstructor", testPathUniqueElementsGraphHashableConstructor),
         ("testCycleUniqueElementsGraphConstructor", testCycleUniqueElementsGraphConstructor),
+        ("testCycleUniqueElementsHashableConstructor", testCycleUniqueElementsHashableConstructor),
         ("testStarGraphConstructor", testStarGraphConstructor),
         ("testCompleteGraphConstructor", testCompleteGraphConstructor),
     ]

--- a/Tests/SwiftGraphPerformanceTests/XCTestManifests.swift
+++ b/Tests/SwiftGraphPerformanceTests/XCTestManifests.swift
@@ -1,0 +1,29 @@
+import XCTest
+
+extension ConstructorsPerformanceTests {
+    static let __allTests = [
+        ("testCompleteGraphConstructor", testCompleteGraphConstructor),
+        ("testCycleUniqueElementsGraphConstructor", testCycleUniqueElementsGraphConstructor),
+        ("testCycleUniqueElementsHashableConstructor", testCycleUniqueElementsHashableConstructor),
+        ("testCycleUnweightedGraphConstructor", testCycleUnweightedGraphConstructor),
+        ("testPathUniqueElementsGraphConstructor", testPathUniqueElementsGraphConstructor),
+        ("testPathUniqueElementsGraphHashableConstructor", testPathUniqueElementsGraphHashableConstructor),
+        ("testPathUnweightedGraphConstructor", testPathUnweightedGraphConstructor),
+        ("testStarGraphConstructor", testStarGraphConstructor),
+    ]
+}
+
+extension SearchPerformanceTests {
+    static let __allTests = [
+        ("testDfsInStarGraph", testDfsInStarGraph),
+    ]
+}
+
+#if !os(macOS)
+public func __allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(ConstructorsPerformanceTests.__allTests),
+        testCase(SearchPerformanceTests.__allTests),
+    ]
+}
+#endif

--- a/Tests/SwiftGraphTests/Constructors/ConstructorsTests.swift
+++ b/Tests/SwiftGraphTests/Constructors/ConstructorsTests.swift
@@ -58,12 +58,4 @@ class ConstructorsTests: XCTestCase {
         XCTAssertEqual(g.edgeCount, 0, "The singleton complete graph must contain no edges")
         XCTAssertEqual(g.vertices, [0], "The singleton complete graph must contain one vertex")
     }
-
-    static var allTests = [
-        ("testStarGraphConstructor", testStarGraphConstructor),
-        ("testSingletonStarGraphConstructor", testSingletonStarGraphConstructor),
-        ("testCompleteGraphConstructor", testCompleteGraphConstructor),
-        ("testEmptyCompleteGraphConstructor", testEmptyCompleteGraphConstructor),
-        ("testSingletonCompleteGraphConstructor", testSingletonCompleteGraphConstructor)
-    ]
 }

--- a/Tests/SwiftGraphTests/CycleTests.swift
+++ b/Tests/SwiftGraphTests/CycleTests.swift
@@ -94,13 +94,6 @@ class CycleTests: XCTestCase {
             XCTFail("Arrays not equal: \(lhs), \(rhs)", line: line)
         }
     }
-    
-    static var allTests = [
-        ("testFullyConnectedVertices", testFullyConnectedVertices),
-        ("testFullyConnectedEdges", testFullyConnectedEdges),
-        ("testDetectCyclesVertices1", testDetectCyclesVertices1),
-        ("testDetectCyclesEdges1", testDetectCyclesEdges1)
-    ]
 }
 
 fileprivate extension Edge {

--- a/Tests/SwiftGraphTests/DijkstraGraphTests.swift
+++ b/Tests/SwiftGraphTests/DijkstraGraphTests.swift
@@ -257,11 +257,4 @@ class DijkstraGraphTests: XCTestCase {
         XCTAssertEqual(stops, ["Miami", "Atlanta", "New York", "Chicago"], "Shortest path to Chicago is not right.")
 
     }
-    
-    static var allTests = [
-        ("testDijksta1", testDijkstra1),
-        ("testDijksta2", testDijkstra2),
-        ("testDijksta3", testDijkstra3),
-        ("testRemovalWithDijksta", testRemovalWithDijkstra)
-    ]
 }

--- a/Tests/SwiftGraphTests/MSTTests.swift
+++ b/Tests/SwiftGraphTests/MSTTests.swift
@@ -120,9 +120,4 @@ class MSTTests: XCTestCase {
         XCTAssertEqual(mst.count, cityGraph2.count - 1, "MST should contain edges between all vertices so count should be # of vertices - 1")
         XCTAssertEqual(totalWeight, 5372, "MST should cost 5372 for cityGraph2")
     }
-    
-    static var allTests = [
-        ("testMST1", testMST1),
-        ("testMST2", testMST2)
-    ]
 }

--- a/Tests/SwiftGraphTests/SwiftGraphCodableTests.swift
+++ b/Tests/SwiftGraphTests/SwiftGraphCodableTests.swift
@@ -234,9 +234,4 @@ extension SwiftGraphCodableTests {
         self.validateDijkstra1(cityGraph: g2)
         //        XCTAssertEqual(g, self.cityGraph())
     }
-    
-    static var allTests = [
-        ("testEncodableDecodable", testEncodableDecodable),
-        ("testComplexWeightedEncodableDecodable", testComplexWeightedEncodableDecodable)
-    ]
 }

--- a/Tests/SwiftGraphTests/SwiftGraphSearchTests.swift
+++ b/Tests/SwiftGraphTests/SwiftGraphSearchTests.swift
@@ -274,26 +274,4 @@ class SwiftGraphSearchTests: XCTestCase {
             XCTAssertTrue(endCities.contains("San Francisco"), "Should contain a route to San Francisco")
         }
     }
-    
-    /*func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measureBlock() {
-            // Put the code you want to measure the time of here.
-        }
-    }*/
-    static var allTests = [
-        ("testDFS1", testDFS1),
-        ("testDFS2", testDFS2),
-        ("testDFS3", testDFS3),
-        ("testDFS4", testDFS4),
-        ("testDFS5", testDFS5),
-        ("testDFS6", testDFS6),
-        ("testBFS1", testBFS1),
-        ("testBFS2", testBFS2),
-        ("testBFS3", testBFS3),
-        ("testBFS4", testBFS4),
-        ("testBFS5", testBFS5),
-        ("testBFS6", testBFS6),
-        ("testFindAll", testFindAll)
-    ]
 }

--- a/Tests/SwiftGraphTests/SwiftGraphSortTests.swift
+++ b/Tests/SwiftGraphTests/SwiftGraphSortTests.swift
@@ -57,9 +57,4 @@ class SwiftGraphSortTests: XCTestCase {
         print(result)
         XCTAssertEqual(result.count, 9, "All items in sort.")
     }
-    
-    static var allTests = [
-        ("testDAG", testDAG),
-        ("testTopologicalSort", testTopologicalSort)
-    ]
 }

--- a/Tests/SwiftGraphTests/SwiftGraphTests.swift
+++ b/Tests/SwiftGraphTests/SwiftGraphTests.swift
@@ -95,18 +95,4 @@ class SwiftGraphTests: XCTestCase {
         XCTAssertFalse(graph.edgeExists(from: 2, to: 3))
         XCTAssertFalse(graph.edgeExists(from: 3, to: 2))
     }
-    
-    //func testPerformanceExample() {
-        // This is an example of a performance test case.
-     //   self.measureBlock() {
-            // Put the code you want to measure the time of here.
-     //   }
-    //}
-    static var allTests = [
-        ("testCitesInverseAfterRemove", testCitesInverseAfterRemove),
-        ("testSequenceTypeAndCollectionType", testSequenceTypeAndCollectionType),
-        ("testCounts", testCounts),
-        ("testSubscript", testSubscript),
-        ("testRemoveAllEdges", testRemoveAllEdges)
-    ]
 }

--- a/Tests/SwiftGraphTests/UnionTests.swift
+++ b/Tests/SwiftGraphTests/UnionTests.swift
@@ -178,19 +178,6 @@ class UnionTests: XCTestCase {
         XCTAssertTrue(g.edgeExists(from: "C", to: "A"), "g: Expected an edge from C to A")
     }
 
-    static var allTests = [
-        ("testEmptyGraph", testEmptyGraph),
-        ("testUnionLastInCommon", testUnionLastInCommon),
-        ("testUnionFirstInCommon", testUnionFirstInCommon),
-        ("testDisjointUnion", testDisjointUnion),
-        ("testImmutabilityOfInputGraphs", testImmutabilityOfInputGraphs),
-        ("testIdentityEmptyGraph", testIdentityEmptyGraph),
-        ("testUnionWithSelf", testUnionWithSelf),
-        ("testCommutativity", testCommutativity),
-        ("testAssociativity", testAssociativity),
-        ("testMultipleParameters", testMultipleParameters)
-    ]
-
     func arraysHaveSameElements<T: Equatable>(_ a1: [T], _ a2: [T]) -> Bool {
         guard a1.count == a2.count else {
             return false

--- a/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphHashableInitTests.swift
+++ b/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphHashableInitTests.swift
@@ -216,12 +216,5 @@ class UniqueElementsGraphHashableInitTests: XCTestCase {
         XCTAssertTrue(g6Cycle.edgeExists(from: "Boston", to: "Eugene"), "g6Cycle: Expected an edge from Boston to Eugene")
         XCTAssertTrue(g6Cycle.edgeExists(from: "Eugene", to: "Atlanta"), "g6Cycle: Expected an edge from Eugene to Atlanta")
     }
-
-    static var allTests = [
-        ("testPathInitializerDirected", testPathInitializerDirected),
-        ("testPathInitializerUndirected", testPathInitializerUndirected),
-        ("testCycleInitializerDirected", testCycleInitializerDirected),
-        ("testCycleInitializerUndirected", testCycleInitializerUndirected)
-    ]
 }
 

--- a/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphHashableInitTests.swift
+++ b/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphHashableInitTests.swift
@@ -1,5 +1,5 @@
 //
-//  UniqueElementsGraphInitTests.swift
+//  UniqueElementsGraphHashableInitTests.swift
 //  SwiftGraphTests
 //
 //  Copyright (c) 2018 Ferran Pujol Camins
@@ -19,32 +19,24 @@
 import XCTest
 @testable import SwiftGraph
 
-struct EquatableString: ExpressibleByStringLiteral, Equatable {
-    init(stringLiteral: String) {
-        s = stringLiteral
-    }
-
-    let s: String
-}
-
-class UniqueElementsGraphInitTests: XCTestCase {
+class UniqueElementsGraphHashableInitTests: XCTestCase {
 
     func testPathInitializerUndirected() {
-        let g0Path = UniqueElementsGraph<EquatableString>(withPath:[])
+        let g0Path = UniqueElementsGraph<String>(withPath:[])
         XCTAssertEqual(g0Path.vertexCount, 0, "g0Path: Expected empty graph")
         XCTAssertEqual(g0Path.edgeCount, 0, "g0Path: Expected empty graph")
 
-        let g1Path = UniqueElementsGraph<EquatableString>(withPath:["Atlanta"])
+        let g1Path = UniqueElementsGraph(withPath:["Atlanta"])
         XCTAssertEqual(g1Path.vertices, ["Atlanta"], "g1Path: Expected only Atlanta vertex")
         XCTAssertEqual(g1Path.edgeCount, 0, "g1Path: Expected no edges")
 
-        let g2Path = UniqueElementsGraph<EquatableString>(withPath:["Atlanta", "Boston"])
+        let g2Path = UniqueElementsGraph(withPath:["Atlanta", "Boston"])
         XCTAssertEqual(g2Path.vertices, ["Atlanta", "Boston"], "g2Path: Expected vertices to be Atlanta and Boston")
         XCTAssertEqual(g2Path.edgeCount, 2, "g2Path: Expected exactly 2 edges")
         XCTAssertTrue(g2Path.edgeExists(from: "Atlanta", to: "Boston"), "g2Path: Expected an edge from Atlanta to Boston")
         XCTAssertTrue(g2Path.edgeExists(from: "Boston", to: "Atlanta"), "g2Path: Expected an edge from Boston to Atlanta")
 
-        let g3Path = UniqueElementsGraph<EquatableString>(withPath:["Atlanta", "Boston", "Chicago"])
+        let g3Path = UniqueElementsGraph(withPath:["Atlanta", "Boston", "Chicago"])
         XCTAssertEqual(g3Path.vertices, ["Atlanta", "Boston", "Chicago"], "g3Path: Expected vertices to be Atlanta, Boston and Chicago")
         XCTAssertEqual(g3Path.edgeCount, 4, "g3Path: Expected exactly 4 edges")
         XCTAssertTrue(g3Path.edgeExists(from: "Atlanta", to: "Boston"), "g3Path: Expected an edge from Atlanta to Boston")
@@ -52,13 +44,13 @@ class UniqueElementsGraphInitTests: XCTestCase {
         XCTAssertTrue(g3Path.edgeExists(from: "Boston", to: "Chicago"), "g3Path: Expected an edge from Boston to Chicago")
         XCTAssertTrue(g3Path.edgeExists(from: "Chicago", to: "Boston"), "g3Path: Expected an edge from Chicago to Boston")
 
-        let g4Path = UniqueElementsGraph<EquatableString>(withPath:["Atlanta", "Boston", "Atlanta"])
+        let g4Path = UniqueElementsGraph(withPath:["Atlanta", "Boston", "Atlanta"])
         XCTAssertEqual(g4Path.vertices, ["Atlanta", "Boston"], "g4Path: Expected vertices to be Atlanta and Boston.")
         XCTAssertEqual(g4Path.edgeCount, 2, "g4Path: Expected exactly 2 edges")
         XCTAssertTrue(g4Path.edgeExists(from: "Atlanta", to: "Boston"), "g4Path: Expected an edge from Atlanta to Boston")
         XCTAssertTrue(g4Path.edgeExists(from: "Boston", to: "Atlanta"), "g4Path: Expected an edge from Boston to Atlanta")
 
-        let g5Path = UniqueElementsGraph<EquatableString>(withPath:["Atlanta", "Boston", "Chicago", "Atlanta", "Denver", "Chicago", "Atlanta"])
+        let g5Path = UniqueElementsGraph(withPath:["Atlanta", "Boston", "Chicago", "Atlanta", "Denver", "Chicago", "Atlanta"])
         XCTAssertEqual(g5Path.vertices, ["Atlanta", "Boston", "Chicago", "Denver"], "g5Path: Expected vertices to be Atlanta, Boston, Chiicago and Denver.")
         XCTAssertEqual(g5Path.edgeCount, 10, "g5Path: Expected exactly 10 edges")
         XCTAssertTrue(g5Path.edgeExists(from: "Atlanta", to: "Boston"), "g5Path: Expected an edge from Atlanta to Boston")
@@ -74,32 +66,32 @@ class UniqueElementsGraphInitTests: XCTestCase {
     }
 
     func testPathInitializerDirected() {
-        let g0Path = UniqueElementsGraph<EquatableString>(withPath:[], directed: true)
+        let g0Path = UniqueElementsGraph<String>(withPath:[], directed: true)
         XCTAssertEqual(g0Path.vertexCount, 0, "g0Path: Expected empty graph")
         XCTAssertEqual(g0Path.edgeCount, 0, "g0Path: Expected empty graph")
 
-        let g1Path = UniqueElementsGraph<EquatableString>(withPath:["Atlanta"], directed: true)
+        let g1Path = UniqueElementsGraph(withPath:["Atlanta"], directed: true)
         XCTAssertEqual(g1Path.vertices, ["Atlanta"], "g1Path: Expected only Atlanta vertex")
         XCTAssertEqual(g1Path.edgeCount, 0, "g1Path: Expected no edges")
 
-        let g2Path = UniqueElementsGraph<EquatableString>(withPath:["Atlanta", "Boston"], directed: true)
+        let g2Path = UniqueElementsGraph(withPath:["Atlanta", "Boston"], directed: true)
         XCTAssertEqual(g2Path.vertices, ["Atlanta", "Boston"], "g2Path: Expected vertices to be Atlanta and Boston")
         XCTAssertEqual(g2Path.edgeCount, 1, "g2Path: Expected exactly 1 edges")
         XCTAssertTrue(g2Path.edgeExists(from: "Atlanta", to: "Boston"), "g2Path: Expected an edge from Atlanta to Boston")
 
-        let g3Path = UniqueElementsGraph<EquatableString>(withPath:["Atlanta", "Boston", "Chicago"], directed: true)
+        let g3Path = UniqueElementsGraph(withPath:["Atlanta", "Boston", "Chicago"], directed: true)
         XCTAssertEqual(g3Path.vertices, ["Atlanta", "Boston", "Chicago"], "g3Path: Expected vertices to be Atlanta, Boston and Chicago")
         XCTAssertEqual(g3Path.edgeCount, 2, "g3Path: Expected exactly 2 edges")
         XCTAssertTrue(g3Path.edgeExists(from: "Atlanta", to: "Boston"), "g3Path: Expected an edge from Atlanta to Boston")
         XCTAssertTrue(g3Path.edgeExists(from: "Boston", to: "Chicago"), "g3Path: Expected an edge from Boston to Chicago")
 
-        let g4Path = UniqueElementsGraph<EquatableString>(withPath:["Atlanta", "Boston", "Atlanta"], directed: true)
+        let g4Path = UniqueElementsGraph(withPath:["Atlanta", "Boston", "Atlanta"], directed: true)
         XCTAssertEqual(g4Path.vertices, ["Atlanta", "Boston"], "g4Path: Expected vertices to be Atlanta and Boston.")
         XCTAssertEqual(g4Path.edgeCount, 2, "g4Path: Expected exactly 2 edges")
         XCTAssertTrue(g4Path.edgeExists(from: "Atlanta", to: "Boston"), "g4Path: Expected an edge from Atlanta to Boston")
         XCTAssertTrue(g4Path.edgeExists(from: "Boston", to: "Atlanta"), "g4Path: Expected an edge from Boston to Atlanta")
 
-        let g5Path = UniqueElementsGraph<EquatableString>(withPath:["Atlanta", "Boston", "Chicago", "Atlanta", "Denver", "Chicago", "Atlanta"], directed: true)
+        let g5Path = UniqueElementsGraph(withPath:["Atlanta", "Boston", "Chicago", "Atlanta", "Denver", "Chicago", "Atlanta"], directed: true)
         XCTAssertEqual(g5Path.vertices, ["Atlanta", "Boston", "Chicago", "Denver"], "g4Path: Expected vertices to be Atlanta, Boston, Chiicago and Denver.")
         XCTAssertEqual(g5Path.edgeCount, 5, "g5Path: Expected exactly 5 edges")
         XCTAssertTrue(g5Path.edgeExists(from: "Atlanta", to: "Boston"), "g5Path: Expected an edge from Atlanta to Boston")
@@ -110,22 +102,22 @@ class UniqueElementsGraphInitTests: XCTestCase {
     }
 
     func testCycleInitializerUndirected() {
-        let g0Cycle = UniqueElementsGraph<EquatableString>(withCycle:[])
+        let g0Cycle = UniqueElementsGraph<String>(withCycle:[])
         XCTAssertEqual(g0Cycle.vertexCount, 0, "g0Cycle: Expected empty graph")
         XCTAssertEqual(g0Cycle.edgeCount, 0, "g0Cycle: Expected empty graph")
 
-        let g1Cycle = UniqueElementsGraph<EquatableString>(withCycle:["Atlanta"])
+        let g1Cycle = UniqueElementsGraph(withCycle:["Atlanta"])
         XCTAssertEqual(g1Cycle.vertices, ["Atlanta"], "g1Cycle: Expected only Atlanta vertex")
         XCTAssertEqual(g1Cycle.edgeCount, 1, "g1Cycle: Expected 1 edges")
         XCTAssertTrue(g1Cycle.edgeExists(from: "Atlanta", to: "Atlanta"), "g1Cycle: Expected an edge from Atlanta to Atlanta")
 
-        let g2Cycle = UniqueElementsGraph<EquatableString>(withCycle:["Atlanta", "Boston"])
+        let g2Cycle = UniqueElementsGraph(withCycle:["Atlanta", "Boston"])
         XCTAssertEqual(g2Cycle.vertices, ["Atlanta", "Boston"], "g2Cycle: Expected vertices to be Atlanta and Boston")
         XCTAssertEqual(g2Cycle.edgeCount, 2, "g2Cycle: Expected exactly 2 edges")
         XCTAssertTrue(g2Cycle.edgeExists(from: "Atlanta", to: "Boston"), "g2Cycle: Expected an edge from Atlanta to Boston")
         XCTAssertTrue(g2Cycle.edgeExists(from: "Boston", to: "Atlanta"), "g2Cycle: Expected an edge from Boston to Atlanta")
 
-        let g3Cycle = UniqueElementsGraph<EquatableString>(withCycle:["Atlanta", "Boston", "Chicago"])
+        let g3Cycle = UniqueElementsGraph(withCycle:["Atlanta", "Boston", "Chicago"])
         XCTAssertEqual(g3Cycle.vertices, ["Atlanta", "Boston", "Chicago"], "g3Cycle: Expected vertices to be Atlanta, Boston and Chicago")
         XCTAssertEqual(g3Cycle.edgeCount, 6, "g3Path: Expected exactly 6 edges")
         XCTAssertTrue(g3Cycle.edgeExists(from: "Atlanta", to: "Boston"), "g3Cycle: Expected an edge from Atlanta to Boston")
@@ -135,14 +127,14 @@ class UniqueElementsGraphInitTests: XCTestCase {
         XCTAssertTrue(g3Cycle.edgeExists(from: "Chicago", to: "Atlanta"), "g3Cycle: Expected an edge from Chicago to Atlanta")
         XCTAssertTrue(g3Cycle.edgeExists(from: "Atlanta", to: "Chicago"), "g3Cycle: Expected an edge from Atlanta to Chicago")
 
-        let g4Cycle = UniqueElementsGraph<EquatableString>(withCycle:["Atlanta", "Boston", "Atlanta"])
+        let g4Cycle = UniqueElementsGraph(withCycle:["Atlanta", "Boston", "Atlanta"])
         XCTAssertEqual(g4Cycle.vertices, ["Atlanta", "Boston"], "g4Cycle: Expected vertices to be Atlanta and Boston.")
         XCTAssertEqual(g4Cycle.edgeCount, 3, "g4Cycle: Expected exactly 3 edges")
         XCTAssertTrue(g4Cycle.edgeExists(from: "Atlanta", to: "Boston"), "g4Cycle: Expected an edge from Atlanta to Boston")
         XCTAssertTrue(g4Cycle.edgeExists(from: "Boston", to: "Atlanta"), "g4Cycle: Expected an edge from Boston to Atlanta")
         XCTAssertTrue(g4Cycle.edgeExists(from: "Atlanta", to: "Atlanta"), "g4Cycle: Expected an edge from Atlanta to Boston")
 
-        let g5Cycle = UniqueElementsGraph<EquatableString>(withCycle:["Atlanta", "Boston", "Chicago", "Atlanta", "Denver", "Chicago", "Atlanta"])
+        let g5Cycle = UniqueElementsGraph(withCycle:["Atlanta", "Boston", "Chicago", "Atlanta", "Denver", "Chicago", "Atlanta"])
         XCTAssertEqual(g5Cycle.vertices, ["Atlanta", "Boston", "Chicago", "Denver"], "g5Cycle: Expected vertices to be Atlanta, Boston, Chiicago and Denver.")
         XCTAssertEqual(g5Cycle.edgeCount, 11, "g5Path: Expected exactly 11 edges")
         XCTAssertTrue(g5Cycle.edgeExists(from: "Atlanta", to: "Boston"), "g5Cycle: Expected an edge from Atlanta to Boston")
@@ -157,7 +149,7 @@ class UniqueElementsGraphInitTests: XCTestCase {
         XCTAssertTrue(g5Cycle.edgeExists(from: "Chicago", to: "Denver"), "g5Cycle: Expected an edge from Chicago to Denver")
         XCTAssertTrue(g5Cycle.edgeExists(from: "Atlanta", to: "Atlanta"), "g5Cycle: Expected an edge from Atlanta to Boston")
 
-        let g6Cycle = UniqueElementsGraph<EquatableString>(withCycle:["Atlanta", "Boston", "Chicago", "Denver", "Boston", "Eugene"])
+        let g6Cycle = UniqueElementsGraph(withCycle:["Atlanta", "Boston", "Chicago", "Denver", "Boston", "Eugene"])
         XCTAssertEqual(g6Cycle.vertices, ["Atlanta", "Boston", "Chicago", "Denver", "Eugene"], "g6Cycle: Expected vertices to be Atlanta, Boston, Chiicago and Denver.")
         XCTAssertEqual(g6Cycle.edgeCount, 12, "g6Cycle: Expected exactly 12 edges")
         XCTAssertTrue(g6Cycle.edgeExists(from: "Atlanta", to: "Boston"), "g6Cycle: Expected an edge from Atlanta to Boston")
@@ -175,36 +167,36 @@ class UniqueElementsGraphInitTests: XCTestCase {
     }
 
     func testCycleInitializerDirected() {
-        let g0Cycle = UniqueElementsGraph<EquatableString>(withCycle:[], directed: true)
+        let g0Cycle = UniqueElementsGraph<String>(withCycle:[], directed: true)
         XCTAssertEqual(g0Cycle.vertexCount, 0, "g0Cycle: Expected empty graph")
         XCTAssertEqual(g0Cycle.edgeCount, 0, "g0Cycle: Expected empty graph")
 
-        let g1Cycle = UniqueElementsGraph<EquatableString>(withCycle:["Atlanta"], directed: true)
+        let g1Cycle = UniqueElementsGraph(withCycle:["Atlanta"], directed: true)
         XCTAssertEqual(g1Cycle.vertices, ["Atlanta"], "g1Cycle: Expected only Atlanta vertex")
         XCTAssertEqual(g1Cycle.edgeCount, 1, "g1Cycle: Expected 1 edge")
         XCTAssertTrue(g1Cycle.edgeExists(from: "Atlanta", to: "Atlanta"), "g1Cycle: Expected an edge from Atlanta to Atlanta")
 
-        let g2Cycle = UniqueElementsGraph<EquatableString>(withCycle:["Atlanta", "Boston"], directed: true)
+        let g2Cycle = UniqueElementsGraph(withCycle:["Atlanta", "Boston"], directed: true)
         XCTAssertEqual(g2Cycle.vertices, ["Atlanta", "Boston"], "g2Cycle: Expected vertices to be Atlanta and Boston")
         XCTAssertEqual(g2Cycle.edgeCount, 2, "g2Cycle: Expected exactly 2 edges")
         XCTAssertTrue(g2Cycle.edgeExists(from: "Atlanta", to: "Boston"), "g2Cycle: Expected an edge from Atlanta to Boston")
         XCTAssertTrue(g2Cycle.edgeExists(from: "Boston", to: "Atlanta"), "g2Cycle: Expected an edge from Atlanta to Boston")
 
-        let g3Cycle = UniqueElementsGraph<EquatableString>(withCycle:["Atlanta", "Boston", "Chicago"], directed: true)
+        let g3Cycle = UniqueElementsGraph(withCycle:["Atlanta", "Boston", "Chicago"], directed: true)
         XCTAssertEqual(g3Cycle.vertices, ["Atlanta", "Boston", "Chicago"], "g3Cycle: Expected vertices to be Atlanta, Boston and Chicago")
         XCTAssertEqual(g3Cycle.edgeCount, 3, "g3Cycle: Expected exactly 4 edges")
         XCTAssertTrue(g3Cycle.edgeExists(from: "Atlanta", to: "Boston"), "g3Cycle: Expected an edge from Atlanta to Boston")
         XCTAssertTrue(g3Cycle.edgeExists(from: "Boston", to: "Chicago"), "g3Cycle: Expected an edge from Boston to Chicago")
         XCTAssertTrue(g3Cycle.edgeExists(from: "Chicago", to: "Atlanta"), "g3Cycle: Expected an edge from Chicago to Atlanta")
 
-        let g4Cycle = UniqueElementsGraph<EquatableString>(withCycle:["Atlanta", "Boston", "Atlanta"], directed: true)
+        let g4Cycle = UniqueElementsGraph(withCycle:["Atlanta", "Boston", "Atlanta"], directed: true)
         XCTAssertEqual(g4Cycle.vertices, ["Atlanta", "Boston"], "g4Cycle: Expected vertices to be Atlanta and Boston.")
         XCTAssertEqual(g4Cycle.edgeCount, 3, "g4Cycle: Expected exactly 3 edges")
         XCTAssertTrue(g4Cycle.edgeExists(from: "Atlanta", to: "Boston"), "g4Cycle: Expected an edge from Atlanta to Boston")
         XCTAssertTrue(g4Cycle.edgeExists(from: "Boston", to: "Atlanta"), "g4Cycle: Expected an edge from Boston to Atlanta")
         XCTAssertTrue(g4Cycle.edgeExists(from: "Atlanta", to: "Atlanta"), "g4Cycle: Expected an edge from Atlanta to Boston")
 
-        let g5Cycle = UniqueElementsGraph<EquatableString>(withCycle:["Atlanta", "Boston", "Chicago", "Atlanta", "Denver", "Chicago", "Atlanta"], directed: true)
+        let g5Cycle = UniqueElementsGraph(withCycle:["Atlanta", "Boston", "Chicago", "Atlanta", "Denver", "Chicago", "Atlanta"], directed: true)
         XCTAssertEqual(g5Cycle.vertices, ["Atlanta", "Boston", "Chicago", "Denver"], "g5Cycle: Expected vertices to be Atlanta, Boston, Chiicago and Denver.")
         XCTAssertEqual(g5Cycle.edgeCount, 6, "g5Path: Expected exactly 6 edges")
         XCTAssertTrue(g5Cycle.edgeExists(from: "Atlanta", to: "Boston"), "g5Cycle: Expected an edge from Atlanta to Boston")
@@ -214,7 +206,7 @@ class UniqueElementsGraphInitTests: XCTestCase {
         XCTAssertTrue(g5Cycle.edgeExists(from: "Denver", to: "Chicago"), "g5Cycle: Expected an edge from Denver to Chicago")
         XCTAssertTrue(g5Cycle.edgeExists(from: "Atlanta", to: "Atlanta"), "g5Cycle: Expected an edge from Atlanta to Boston")
 
-        let g6Cycle = UniqueElementsGraph<EquatableString>(withCycle:["Atlanta", "Boston", "Chicago", "Denver", "Boston", "Eugene"], directed: true)
+        let g6Cycle = UniqueElementsGraph(withCycle:["Atlanta", "Boston", "Chicago", "Denver", "Boston", "Eugene"], directed: true)
         XCTAssertEqual(g6Cycle.vertices, ["Atlanta", "Boston", "Chicago", "Denver", "Eugene"], "g6Cycle: Expected vertices to be Atlanta, Boston, Chiicago and Denver.")
         XCTAssertEqual(g6Cycle.edgeCount, 6, "g6Cycle: Expected exactly 6 edges")
         XCTAssertTrue(g6Cycle.edgeExists(from: "Atlanta", to: "Boston"), "g6Cycle: Expected an edge from Atlanta to Boston")

--- a/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphHashableTests.swift
+++ b/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphHashableTests.swift
@@ -1,6 +1,6 @@
 //
-//  UniqueElementsGraphTests.swift
-//  SwiftGraphTests
+//  UniqueElementsGraphHashableTests.swift
+//  SwiftGraph
 //
 //  Copyright (c) 2018 Ferran Pujol Camins
 //
@@ -19,7 +19,7 @@
 import XCTest
 @testable import SwiftGraph
 
-class UniqueElementsGraphHashableTests: XCTestCase {
+class UniqueElementsGraphTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
@@ -32,12 +32,12 @@ class UniqueElementsGraphHashableTests: XCTestCase {
     }
 
     func testUniqueVertexAfterInit() {
-        let g = UniqueElementsGraph<EquatableString>(vertices:["Atlanta", "Atlanta"])
+        let g = UniqueElementsGraph<String>(vertices:["Atlanta", "Atlanta"])
         XCTAssertEqual(g.vertices, ["Atlanta"], "Expected one vertex")
     }
 
     func testUniqueVertexAfterAddition() {
-        let g = UniqueElementsGraph<EquatableString>()
+        let g = UniqueElementsGraph<String>()
         _ = g.addVertex("Atlanta")
         XCTAssertEqual(g.vertices, ["Atlanta"], "Expected one vertex")
 
@@ -46,7 +46,7 @@ class UniqueElementsGraphHashableTests: XCTestCase {
     }
     
     func testUniqueUndirectedEdges() {
-        let g = UniqueElementsGraph<EquatableString>(vertices:["Atlanta", "Chicago"])
+        let g = UniqueElementsGraph<String>(vertices:["Atlanta", "Chicago"])
         g.addEdge(from: "Atlanta", to: "Chicago", directed: false)
         g.addEdge(from: "Atlanta", to: "Chicago", directed: false)
         XCTAssertTrue(g.edgeExists(from: "Atlanta", to: "Chicago"), "Expected an edge from Atlanta to Chicago")
@@ -55,7 +55,7 @@ class UniqueElementsGraphHashableTests: XCTestCase {
     }
 
     func testUniqueUndirectedEdges2() {
-        let g = UniqueElementsGraph<EquatableString>(vertices:["Atlanta", "Boston", "Chicago"])
+        let g = UniqueElementsGraph<String>(vertices:["Atlanta", "Boston", "Chicago"])
         g.addEdge(from: "Chicago", to: "Boston", directed: false)
         g.addEdge(from: "Atlanta", to: "Chicago", directed: false)
         XCTAssertTrue(g.edgeExists(from: "Atlanta", to: "Chicago"), "Expected an edge from Atlanta to Chicago")
@@ -66,7 +66,7 @@ class UniqueElementsGraphHashableTests: XCTestCase {
     }
 
     func testUniqueUndirectedLoop() {
-        let g = UniqueElementsGraph<EquatableString>(vertices:["Atlanta"])
+        let g = UniqueElementsGraph(vertices:["Atlanta"])
         g.addEdge(from: "Atlanta", to: "Atlanta", directed: false)
         XCTAssertTrue(g.edgeExists(from: "Atlanta", to: "Atlanta"), "Expected an edge from Atlanta to Atlanta")
         XCTAssertEqual(g.edgeCount, 1, "Expect one edge")
@@ -76,7 +76,7 @@ class UniqueElementsGraphHashableTests: XCTestCase {
     }
 
     func testUniqueUndirectedLoop2() {
-        let g = UniqueElementsGraph<EquatableString>(vertices:["Atlanta", "Boston"])
+        let g = UniqueElementsGraph(vertices:["Atlanta", "Boston"])
         g.addEdge(from: "Atlanta", to: "Boston", directed: false)
         g.addEdge(from: "Atlanta", to: "Atlanta", directed: false)
         XCTAssertTrue(g.edgeExists(from: "Atlanta", to: "Atlanta"), "Expected an edge from Atlanta to Atlanta")
@@ -87,7 +87,7 @@ class UniqueElementsGraphHashableTests: XCTestCase {
     }
 
     func testUniqueDirectedEdges() {
-        let g = UniqueElementsGraph<EquatableString>(vertices:["Atlanta", "Chicago"])
+        let g = UniqueElementsGraph<String>(vertices:["Atlanta", "Chicago"])
         g.addEdge(from: "Atlanta", to: "Chicago", directed: true)
         g.addEdge(from: "Atlanta", to: "Chicago", directed: true)
         XCTAssertTrue(g.edgeExists(from: "Atlanta", to: "Chicago"), "Expected an edge from Atlanta to Chicago")
@@ -95,7 +95,7 @@ class UniqueElementsGraphHashableTests: XCTestCase {
     }
 
     func testUniqueDirectedLoop() {
-        let g = UniqueElementsGraph<EquatableString>(vertices:["Atlanta"])
+        let g = UniqueElementsGraph(vertices:["Atlanta"])
         g.addEdge(from: "Atlanta", to: "Atlanta", directed: true)
         XCTAssertTrue(g.edgeExists(from: "Atlanta", to: "Atlanta"), "Expected an edge from Atlanta to Atlanta")
         XCTAssertEqual(g.edgeCount, 1, "Expected one edges")
@@ -105,7 +105,7 @@ class UniqueElementsGraphHashableTests: XCTestCase {
     }
 
     func testUniqueDirectedLoop2() {
-        let g = UniqueElementsGraph<EquatableString>(vertices:["Atlanta", "Boston"])
+        let g = UniqueElementsGraph(vertices:["Atlanta", "Boston"])
         g.addEdge(from: "Atlanta", to: "Boston", directed: true)
         g.addEdge(from: "Atlanta", to: "Atlanta", directed: true)
         XCTAssertTrue(g.edgeExists(from: "Atlanta", to: "Atlanta"), "Expected an edge from Atlanta to Atlanta")
@@ -116,7 +116,7 @@ class UniqueElementsGraphHashableTests: XCTestCase {
     }
     
     func testUniqueEdgesCombined() {
-        let g = UniqueElementsGraph<EquatableString>(vertices:["Atlanta", "Chicago"])
+        let g = UniqueElementsGraph<String>(vertices:["Atlanta", "Chicago"])
         g.addEdge(from: "Atlanta", to: "Chicago", directed: false)
         g.addEdge(from: "Atlanta", to: "Chicago", directed: true)
         XCTAssertTrue(g.edgeExists(from: "Atlanta", to: "Chicago"), "Expected an edge from Atlanta to Chicago")

--- a/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphHashableTests.swift
+++ b/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphHashableTests.swift
@@ -123,17 +123,4 @@ class UniqueElementsGraphTests: XCTestCase {
         XCTAssertTrue(g.edgeExists(from: "Chicago", to: "Atlanta"), "Expected an edge from Chicago to Atlanta")
         XCTAssertEqual(g.edgeCount, 2, "Expected two edges")
     }
-
-    static var allTests = [
-        ("testUniqueVertexAfterAddition", testUniqueVertexAfterAddition),
-        ("testUniqueVertexAfterInit", testUniqueVertexAfterInit),
-        ("testUniqueUndirectedEdges", testUniqueUndirectedEdges),
-        ("testUniqueUndirectedEdges2", testUniqueUndirectedEdges2),
-        ("testUniqueUndirectedLoop", testUniqueUndirectedLoop),
-        ("testUniqueUndirectedLoop2", testUniqueUndirectedLoop2),
-        ("testUniqueDirectedEdges", testUniqueDirectedEdges),
-        ("testUniqueDirectedLoop", testUniqueDirectedLoop),
-        ("testUniqueDirectedLoop2", testUniqueDirectedLoop),
-        ("testUniqueEdgesCombined", testUniqueEdgesCombined)
-    ]
 }

--- a/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphInitTests.swift
+++ b/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphInitTests.swift
@@ -216,12 +216,5 @@ class UniqueElementsGraphInitTests: XCTestCase {
         XCTAssertTrue(g6Cycle.edgeExists(from: "Boston", to: "Eugene"), "g6Cycle: Expected an edge from Boston to Eugene")
         XCTAssertTrue(g6Cycle.edgeExists(from: "Eugene", to: "Atlanta"), "g6Cycle: Expected an edge from Eugene to Atlanta")
     }
-
-    static var allTests = [
-        ("testPathInitializerDirected", testPathInitializerDirected),
-        ("testPathInitializerUndirected", testPathInitializerUndirected),
-        ("testCycleInitializerDirected", testCycleInitializerDirected),
-        ("testCycleInitializerUndirected", testCycleInitializerUndirected)
-    ]
 }
 

--- a/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphInitTests.swift
+++ b/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphInitTests.swift
@@ -19,14 +19,6 @@
 import XCTest
 @testable import SwiftGraph
 
-struct EquatableString: ExpressibleByStringLiteral, Equatable {
-    init(stringLiteral: String) {
-        s = stringLiteral
-    }
-
-    let s: String
-}
-
 class UniqueElementsGraphInitTests: XCTestCase {
 
     func testPathInitializerUndirected() {

--- a/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphTests.swift
+++ b/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphTests.swift
@@ -123,17 +123,4 @@ class UniqueElementsGraphHashableTests: XCTestCase {
         XCTAssertTrue(g.edgeExists(from: "Chicago", to: "Atlanta"), "Expected an edge from Chicago to Atlanta")
         XCTAssertEqual(g.edgeCount, 2, "Expected two edges")
     }
-
-    static var allTests = [
-        ("testUniqueVertexAfterAddition", testUniqueVertexAfterAddition),
-        ("testUniqueVertexAfterInit", testUniqueVertexAfterInit),
-        ("testUniqueUndirectedEdges", testUniqueUndirectedEdges),
-        ("testUniqueUndirectedEdges2", testUniqueUndirectedEdges2),
-        ("testUniqueUndirectedLoop", testUniqueUndirectedLoop),
-        ("testUniqueUndirectedLoop2", testUniqueUndirectedLoop2),
-        ("testUniqueDirectedEdges", testUniqueDirectedEdges),
-        ("testUniqueDirectedLoop", testUniqueDirectedLoop),
-        ("testUniqueDirectedLoop2", testUniqueDirectedLoop),
-        ("testUniqueEdgesCombined", testUniqueEdgesCombined)
-    ]
 }

--- a/Tests/SwiftGraphTests/UnweightedGraphTests.swift
+++ b/Tests/SwiftGraphTests/UnweightedGraphTests.swift
@@ -126,12 +126,5 @@ class UnweightedGraphTests: XCTestCase {
         XCTAssertTrue(g3Cycle.edgeExists(from: "Boston", to: "Chicago"), "g3Cycle: Expected an edge from Boston to Chicago")
         XCTAssertTrue(g3Cycle.edgeExists(from: "Chicago", to: "Atlanta"), "g3Cycle: Expected an edge from Chicago to Atlanta")
     }
-
-    static var allTests = [
-        ("testPathInitializerDirected", testPathInitializerDirected),
-        ("testPathInitializerUndirected", testPathInitializerUndirected),
-        ("testCycleInitializerDirected", testCycleInitializerDirected),
-        ("testCycleInitializerUndirected", testCycleInitializerUndirected)
-    ]
 }
 

--- a/Tests/SwiftGraphTests/Utils/EquatableTypes.swift
+++ b/Tests/SwiftGraphTests/Utils/EquatableTypes.swift
@@ -1,0 +1,25 @@
+//
+//  EquatableTypes.swift
+//  SwiftGraphTests
+//
+//  Copyright (c) 2018 Ferran Pujol Camins
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+struct EquatableString: ExpressibleByStringLiteral, Equatable {
+    init(stringLiteral: String) {
+        s = stringLiteral
+    }
+
+    let s: String
+}

--- a/Tests/SwiftGraphTests/Utils/EquatableTypes.swift
+++ b/Tests/SwiftGraphTests/Utils/EquatableTypes.swift
@@ -16,6 +16,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+/// A wrapper around String but dropping Hashable conformance
 struct EquatableString: ExpressibleByStringLiteral, Equatable {
     init(stringLiteral: String) {
         s = stringLiteral

--- a/Tests/SwiftGraphTests/XCTestManifests.swift
+++ b/Tests/SwiftGraphTests/XCTestManifests.swift
@@ -1,0 +1,171 @@
+import XCTest
+
+extension ConstructorsTests {
+    static let __allTests = [
+        ("testCompleteGraphConstructor", testCompleteGraphConstructor),
+        ("testEmptyCompleteGraphConstructor", testEmptyCompleteGraphConstructor),
+        ("testSingletonCompleteGraphConstructor", testSingletonCompleteGraphConstructor),
+        ("testSingletonStarGraphConstructor", testSingletonStarGraphConstructor),
+        ("testStarGraphConstructor", testStarGraphConstructor),
+    ]
+}
+
+extension CycleTests {
+    static let __allTests = [
+        ("testDetectCyclesEdges1", testDetectCyclesEdges1),
+        ("testDetectCyclesVertices1", testDetectCyclesVertices1),
+        ("testFullyConnectedEdges", testFullyConnectedEdges),
+        ("testFullyConnectedVertices", testFullyConnectedVertices),
+    ]
+}
+
+extension DijkstraGraphTests {
+    static let __allTests = [
+        ("testDijkstra1", testDijkstra1),
+        ("testDijkstra2", testDijkstra2),
+        ("testDijkstra3", testDijkstra3),
+        ("testRemovalWithDijkstra", testRemovalWithDijkstra),
+    ]
+}
+
+extension MSTTests {
+    static let __allTests = [
+        ("testMST1", testMST1),
+        ("testMST2", testMST2),
+    ]
+}
+
+extension SwiftGraphCodableTests {
+    static let __allTests = [
+        ("testComplexWeightedEncodableDecodable", testComplexWeightedEncodableDecodable),
+        ("testEncodableDecodable", testEncodableDecodable),
+    ]
+}
+
+extension SwiftGraphSearchTests {
+    static let __allTests = [
+        ("testBFS1", testBFS1),
+        ("testBFS2", testBFS2),
+        ("testBFS3", testBFS3),
+        ("testBFS4", testBFS4),
+        ("testBFS5", testBFS5),
+        ("testBFS6", testBFS6),
+        ("testDFS1", testDFS1),
+        ("testDFS2", testDFS2),
+        ("testDFS3", testDFS3),
+        ("testDFS4", testDFS4),
+        ("testDFS5", testDFS5),
+        ("testDFS6", testDFS6),
+        ("testFindAll", testFindAll),
+    ]
+}
+
+extension SwiftGraphSortTests {
+    static let __allTests = [
+        ("testDAG", testDAG),
+        ("testTopologicalSort", testTopologicalSort),
+    ]
+}
+
+extension SwiftGraphTests {
+    static let __allTests = [
+        ("testCitesInverseAfterRemove", testCitesInverseAfterRemove),
+        ("testCounts", testCounts),
+        ("testRemoveAllEdges", testRemoveAllEdges),
+        ("testSequenceTypeAndCollectionType", testSequenceTypeAndCollectionType),
+        ("testSubscript", testSubscript),
+    ]
+}
+
+extension UnionTests {
+    static let __allTests = [
+        ("testAssociativity", testAssociativity),
+        ("testCommutativity", testCommutativity),
+        ("testDisjointUnion", testDisjointUnion),
+        ("testEmptyGraph", testEmptyGraph),
+        ("testIdentityEmptyGraph", testIdentityEmptyGraph),
+        ("testImmutabilityOfInputGraphs", testImmutabilityOfInputGraphs),
+        ("testMultipleParameters", testMultipleParameters),
+        ("testUnionFirstInCommon", testUnionFirstInCommon),
+        ("testUnionLastInCommon", testUnionLastInCommon),
+        ("testUnionWithSelf", testUnionWithSelf),
+    ]
+}
+
+extension UniqueElementsGraphHashableInitTests {
+    static let __allTests = [
+        ("testCycleInitializerDirected", testCycleInitializerDirected),
+        ("testCycleInitializerUndirected", testCycleInitializerUndirected),
+        ("testPathInitializerDirected", testPathInitializerDirected),
+        ("testPathInitializerUndirected", testPathInitializerUndirected),
+    ]
+}
+
+extension UniqueElementsGraphHashableTests {
+    static let __allTests = [
+        ("testUniqueDirectedEdges", testUniqueDirectedEdges),
+        ("testUniqueDirectedLoop", testUniqueDirectedLoop),
+        ("testUniqueDirectedLoop2", testUniqueDirectedLoop2),
+        ("testUniqueEdgesCombined", testUniqueEdgesCombined),
+        ("testUniqueUndirectedEdges", testUniqueUndirectedEdges),
+        ("testUniqueUndirectedEdges2", testUniqueUndirectedEdges2),
+        ("testUniqueUndirectedLoop", testUniqueUndirectedLoop),
+        ("testUniqueUndirectedLoop2", testUniqueUndirectedLoop2),
+        ("testUniqueVertexAfterAddition", testUniqueVertexAfterAddition),
+        ("testUniqueVertexAfterInit", testUniqueVertexAfterInit),
+    ]
+}
+
+extension UniqueElementsGraphInitTests {
+    static let __allTests = [
+        ("testCycleInitializerDirected", testCycleInitializerDirected),
+        ("testCycleInitializerUndirected", testCycleInitializerUndirected),
+        ("testPathInitializerDirected", testPathInitializerDirected),
+        ("testPathInitializerUndirected", testPathInitializerUndirected),
+    ]
+}
+
+extension UniqueElementsGraphTests {
+    static let __allTests = [
+        ("testUniqueDirectedEdges", testUniqueDirectedEdges),
+        ("testUniqueDirectedLoop", testUniqueDirectedLoop),
+        ("testUniqueDirectedLoop2", testUniqueDirectedLoop2),
+        ("testUniqueEdgesCombined", testUniqueEdgesCombined),
+        ("testUniqueUndirectedEdges", testUniqueUndirectedEdges),
+        ("testUniqueUndirectedEdges2", testUniqueUndirectedEdges2),
+        ("testUniqueUndirectedLoop", testUniqueUndirectedLoop),
+        ("testUniqueUndirectedLoop2", testUniqueUndirectedLoop2),
+        ("testUniqueVertexAfterAddition", testUniqueVertexAfterAddition),
+        ("testUniqueVertexAfterInit", testUniqueVertexAfterInit),
+    ]
+}
+
+extension UnweightedGraphTests {
+    static let __allTests = [
+        ("testCycleInitializerDirected", testCycleInitializerDirected),
+        ("testCycleInitializerUndirected", testCycleInitializerUndirected),
+        ("testPathInitializerDirected", testPathInitializerDirected),
+        ("testPathInitializerUndirected", testPathInitializerUndirected),
+    ]
+}
+
+#if !os(macOS)
+public func __allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(ConstructorsTests.__allTests),
+        testCase(CycleTests.__allTests),
+        testCase(DijkstraGraphTests.__allTests),
+        testCase(MSTTests.__allTests),
+        testCase(SwiftGraphCodableTests.__allTests),
+        testCase(SwiftGraphSearchTests.__allTests),
+        testCase(SwiftGraphSortTests.__allTests),
+        testCase(SwiftGraphTests.__allTests),
+        testCase(UnionTests.__allTests),
+        testCase(UniqueElementsGraphHashableInitTests.__allTests),
+        testCase(UniqueElementsGraphHashableTests.__allTests),
+        testCase(UniqueElementsGraphInitTests.__allTests),
+        testCase(UniqueElementsGraphTests.__allTests),
+        testCase(UnweightedGraphTests.__allTests),
+    ]
+}
+#endif


### PR DESCRIPTION
In this PR I've added performance tests for the path and cycle constructors. This constructors were performing subpar.
I've improved the performance to bring it to the same level as the star graph constructor for UnweightedGraph.
For UniqueElementsGraph, I've improved the performance by 34% in the general case and by 66% when vertices are Hashable. This is possible through specialized class extensions. But in order to do so easily, UniqueElementsGraph is no longer a subclass of UnweightedGraph, which actually makes sense to me since Graph is now a protocol.