### PR TITLE
Fix dfs bug

### DIFF
--- a/Sources/SwiftGraph/Search.swift
+++ b/Sources/SwiftGraph/Search.swift
@@ -33,17 +33,16 @@ public extension Graph {
         let stack: Stack<Int> = Stack<Int>()
         var pathDict: [Int: E] = [Int: E]()
         stack.push(fromIndex)
-        visited[fromIndex] = true
         while !stack.isEmpty {
             let v: Int = stack.pop()
             if goalTest(vertexAtIndex(v)) {
                 // figure out route of edges based on pathDict
                 return pathDictToPath(from: fromIndex, to: v, pathDict: pathDict) as! [Self.E]
             }
+            visited[v] = true
             for e in edgesForIndex(v) {
                 if !visited[e.v] {
                     stack.push(e.v)
-                    visited[e.v] = true
                     pathDict[e.v] = e
                 }
             }
@@ -75,17 +74,16 @@ public extension Graph {
         let stack: Stack<Int> = Stack<Int>()
         var pathDict: [Int: Edge] = [Int: Edge]()
         stack.push(fromIndex)
-        visited[fromIndex] = true
         while !stack.isEmpty {
             let v: Int = stack.pop()
             if v == toIndex {
                 // figure out route of edges based on pathDict
                 return pathDictToPath(from: fromIndex, to: toIndex, pathDict: pathDict) as! [Self.E]
             }
+            visited[v] = true
             for e in edgesForIndex(v) {
                 if !visited[e.v] {
                     stack.push(e.v)
-                    visited[e.v] = true
                     pathDict[e.v] = e
                 }
             }

--- a/Tests/SwiftGraphTests/SwiftGraphSearchTests.swift
+++ b/Tests/SwiftGraphTests/SwiftGraphSearchTests.swift
@@ -286,6 +286,22 @@ class SwiftGraphSearchTests: XCTestCase {
         }
         print(cityGraph2.edgesToVertices(edges: result))
     }
+
+    func testBFSWithCycle() {
+        let g = CompleteGraph.build(withVertices: ["A", "B", "C"])
+
+        let paths = [
+            g.bfs(from: "A", to: "C"),
+            g.bfs(from: "A", to: "B"),
+            g.bfs(from: "B", to: "A"),
+            g.bfs(from: "B", to: "C"),
+            g.bfs(from: "C", to: "A"),
+            g.bfs(from: "C", to: "B")
+        ]
+
+        let allPathsHavLenght1 = paths.allSatisfy { $0.count == 1 }
+        XCTAssertTrue(allPathsHavLenght1, "In a Triangle Graph, the bfs must visit all nodes directly.")
+    }
     
     func testFindAll() {
         // New York -> all cities starting with "S"

--- a/Tests/SwiftGraphTests/SwiftGraphSearchTests.swift
+++ b/Tests/SwiftGraphTests/SwiftGraphSearchTests.swift
@@ -179,7 +179,28 @@ class SwiftGraphSearchTests: XCTestCase {
         XCTAssertTrue(result.isEmpty, "Found a city starting with Z when there's none.")
         print(cityGraph2.edgesToVertices(edges: result))
     }
-    
+
+    func testDFSWithCycle() {
+        let g = CompleteGraph.build(withVertices: ["A", "B", "C"])
+
+        let paths = [
+            g.dfs(from: "A", to: "C"),
+            g.dfs(from: "A", to: "B"),
+            g.dfs(from: "B", to: "A"),
+            g.dfs(from: "B", to: "C"),
+            g.dfs(from: "C", to: "A"),
+            g.dfs(from: "C", to: "B"),
+        ]
+
+        // Since we don't specify the visit order of the neighbours of a vertex, we can't assure
+        // all paths have lenght 2. By now, we are happy only asserting that at least one of the paths
+        // is lenght 2. This indicates that we are not prematurely marking as visited the neighbours
+        // of the current vertex.
+        let atLeastOnePathHasLenght2 = paths.first(where: { $0.count == 2 }) != nil
+
+        XCTAssertTrue(atLeastOnePathHasLenght2, "In a Complete Graph, the dfs must visit all nodes in the same path")
+    }
+
     func testBFS1() {
         // Seattle -> Miami
         let result = cityGraph.bfs(from: "Seattle", to: "Miami")


### PR DESCRIPTION
In https://github.com/davecom/SwiftGraph/pull/51#issuecomment-431965125 you were right! I introduced a bug when the graph has cycles. That commit was marking all the neighbours as visited when enqueueing them insted of when actually visiting them. This caused that vertices that are neighbours of a visited vertex could not be visited until unqueued. For example, on the triangle graph, the path found was always of lenght 1, when it should be of lenght 2.

I've added a test for this and reverted the commit. Sorry for introducing the bug.