### PR TITLE
Add infinite traversal methods

### DIFF
--- a/Sources/SwiftGraph/Search.swift
+++ b/Sources/SwiftGraph/Search.swift
@@ -21,6 +21,21 @@
 // MARK: Depth-First Search and Breadth-First Search Extensions to `Graph`
 public extension Graph {
 
+    /// Perform a computation over the graph visiting the vertices using a
+    /// depth-first algorithm.
+    ///
+    /// The vertices of the graph are visited one time at most.
+    ///
+    /// - Parameters:
+    ///   - initalVertexIndex: The index of the vertex that will be visited first.
+    ///   - goalTest: Returns true if a given vertex index is a goal.
+    ///   - visitOrder: A closure that orders an array of edges. For each visited vertex, the array
+    ///                 of its outgoing edges will be passed to this closure and the neighbours will
+    ///                 be visited in the order of the resulting array.
+    ///   - reducer: A closure that is fed with each visited vertex. The input parameter
+    ///              is the edge from the previously visited vertex to the currently visited vertex.
+    ///              If the return value is false, the neighbours of the currently visited vertex won't be visited.
+    /// - Returns: The index of the first vertex found to satisfy goalTest or nil if no vertex is found.
     public func dfs(fromIndex initalVertexIndex: Int,
                     goalTest: (Int) -> Bool,
                     visitOrder: ([E]) -> [E],
@@ -198,6 +213,21 @@ public extension Graph {
         return []
     }
 
+    /// Perform a computation over the graph visiting the vertices using a
+    /// breadth-first algorithm.
+    ///
+    /// The vertices of the graph are visited one time at most.
+    ///
+    /// - Parameters:
+    ///   - initalVertexIndex: The index of the vertex that will be visited first.
+    ///   - goalTest: Returns true if a given vertex index is a goal.
+    ///   - visitOrder: A closure that orders an array of edges. For each visited vertex, the array
+    ///                 of its outgoing edges will be passed to this closure and the neighbours will
+    ///                 be visited in the order of the resulting array.
+    ///   - reducer: A closure that is fed with each visited vertex. The input parameter
+    ///              is the edge from the previously visited vertex to the currently visited vertex.
+    ///              If the return value is false, the neighbours of the currently visited vertex won't be visited.
+    /// - Returns: The index of the first vertex found to satisfy goalTest or nil if no vertex is found.
     public func bfs(fromIndex initalVertexIndex: Int,
                     goalTest: (Int) -> Bool,
                     visitOrder: ([E]) -> [E],

--- a/Sources/SwiftGraph/Search.swift
+++ b/Sources/SwiftGraph/Search.swift
@@ -77,6 +77,53 @@ public extension Graph {
         return nil // no route found
     }
 
+    /// Perform a computation over the graph visiting the vertices using a
+    /// depth-first algorithm.
+    ///
+    /// The vertices of the graph can be visited more than once. This means that the algorithm is
+    /// not guaranteed to terminate if tha graph has cycles, it dependes on what goalTest and reducer are used.
+    ///
+    /// - Parameters:
+    ///   - initalVertexIndex: The index of the vertex that will be visited first.
+    ///   - goalTest: Returns true if a given vertex index is a goal.
+    ///   - visitOrder: A closure that orders an array of edges. For each visited vertex, the array
+    ///                 of its outgoing edges will be passed to this closure and the neighbours will
+    ///                 be visited in the order of the resulting array.
+    ///   - reducer: A closure that is fed with each visited vertex. The input parameter
+    ///              is the edge from the previously visited vertex to the currently visited vertex.
+    ///              If the return value is false, the neighbours of the currently visited vertex won't be visited.
+    /// - Returns: The index of the first vertex found to satisfy goalTest or nil if no vertex is found.
+    public func traverseDfs(fromIndex initalVertexIndex: Int,
+                            goalTest: (Int) -> Bool,
+                            visitOrder: ([E]) -> [E],
+                            reducer: (E) -> Bool) -> Int? {
+
+        if goalTest(initalVertexIndex) {
+            return initalVertexIndex
+        }
+        let container = Stack<E>()
+
+        let neighbours = edgesForIndex(initalVertexIndex)
+        for e in visitOrder(neighbours) {
+            container.push(e)
+        }
+        while !container.isEmpty {
+            let edge: E = container.pop()
+            let v = edge.v
+            let shouldVisitNeighbours = reducer(edge)
+            if goalTest(v) {
+                return v
+            }
+            if shouldVisitNeighbours {
+                let neighbours = edgesForIndex(v)
+                for e in visitOrder(neighbours) {
+                    container.push(e)
+                }
+            }
+        }
+        return nil // no route found
+    }
+
     /// Find a route from a vertex to the first that satisfies goalTest()
     /// using a depth-first search.
     ///
@@ -266,6 +313,54 @@ public extension Graph {
         }
         return nil // no route found
     }
+
+    /// Perform a computation over the graph visiting the vertices using a
+    /// breadth-first algorithm.
+    ///
+    /// The vertices of the graph can be visited more than once. This means that the algorithm is
+    /// not guaranteed to terminate if tha graph has cycles, it dependes on what goalTest and reducer are used.
+    ///
+    /// - Parameters:
+    ///   - initalVertexIndex: The index of the vertex that will be visited first.
+    ///   - goalTest: Returns true if a given vertex index is a goal.
+    ///   - visitOrder: A closure that orders an array of edges. For each visited vertex, the array
+    ///                 of its outgoing edges will be passed to this closure and the neighbours will
+    ///                 be visited in the order of the resulting array.
+    ///   - reducer: A closure that is fed with each visited vertex. The input parameter
+    ///              is the edge from the previously visited vertex to the currently visited vertex.
+    ///              If the return value is false, the neighbours of the currently visited vertex won't be visited.
+    /// - Returns: The index of the first vertex found to satisfy goalTest or nil if no vertex is found.
+    public func traverseBfs(fromIndex initalVertexIndex: Int,
+                            goalTest: (Int) -> Bool,
+                            visitOrder: ([E]) -> [E],
+                            reducer: (E) -> Bool) -> Int? {
+
+        if goalTest(initalVertexIndex) {
+            return initalVertexIndex
+        }
+        let container = Queue<E>()
+
+        let neighbours = edgesForIndex(initalVertexIndex)
+        for e in visitOrder(neighbours) {
+            container.push(e)
+        }
+        while !container.isEmpty {
+            let edge: E = container.pop()
+            let v = edge.v
+            let shouldVisitNeighbours = reducer(edge)
+            if goalTest(v) {
+                return v
+            }
+            if shouldVisitNeighbours {
+                let neighbours = edgesForIndex(v)
+                for e in visitOrder(neighbours) {
+                    container.push(e)
+                }
+            }
+        }
+        return nil // no route found
+    }
+
 
     /// Find a route from a vertex to the first that satisfies goalTest()
     /// using a breadth-first search.

--- a/Sources/SwiftGraph/Search.swift
+++ b/Sources/SwiftGraph/Search.swift
@@ -32,7 +32,7 @@ public extension Graph {
     ///   - visitOrder: A closure that orders an array of edges. For each visited vertex, the array
     ///                 of its outgoing edges will be passed to this closure and the neighbours will
     ///                 be visited in the order of the resulting array.
-    ///   - reducer: A closure that is fed with each visited vertex. The input parameter
+    ///   - reducer: A closure that is fed with each visited edge. The input parameter
     ///              is the edge from the previously visited vertex to the currently visited vertex.
     ///              If the return value is false, the neighbours of the currently visited vertex won't be visited.
     /// - Returns: The index of the first vertex found to satisfy goalTest or nil if no vertex is found.
@@ -89,7 +89,7 @@ public extension Graph {
     ///   - visitOrder: A closure that orders an array of edges. For each visited vertex, the array
     ///                 of its outgoing edges will be passed to this closure and the neighbours will
     ///                 be visited in the order of the resulting array.
-    ///   - reducer: A closure that is fed with each visited vertex. The input parameter
+    ///   - reducer: A closure that is fed with each visited edge. The input parameter
     ///              is the edge from the previously visited vertex to the currently visited vertex.
     ///              If the return value is false, the neighbours of the currently visited vertex won't be visited.
     /// - Returns: The index of the first vertex found to satisfy goalTest or nil if no vertex is found.
@@ -271,7 +271,7 @@ public extension Graph {
     ///   - visitOrder: A closure that orders an array of edges. For each visited vertex, the array
     ///                 of its outgoing edges will be passed to this closure and the neighbours will
     ///                 be visited in the order of the resulting array.
-    ///   - reducer: A closure that is fed with each visited vertex. The input parameter
+    ///   - reducer: A closure that is fed with each visited edge. The input parameter
     ///              is the edge from the previously visited vertex to the currently visited vertex.
     ///              If the return value is false, the neighbours of the currently visited vertex won't be visited.
     /// - Returns: The index of the first vertex found to satisfy goalTest or nil if no vertex is found.
@@ -326,7 +326,7 @@ public extension Graph {
     ///   - visitOrder: A closure that orders an array of edges. For each visited vertex, the array
     ///                 of its outgoing edges will be passed to this closure and the neighbours will
     ///                 be visited in the order of the resulting array.
-    ///   - reducer: A closure that is fed with each visited vertex. The input parameter
+    ///   - reducer: A closure that is fed with each visited edge. The input parameter
     ///              is the edge from the previously visited vertex to the currently visited vertex.
     ///              If the return value is false, the neighbours of the currently visited vertex won't be visited.
     /// - Returns: The index of the first vertex found to satisfy goalTest or nil if no vertex is found.

--- a/Tests/SwiftGraphTests/SwiftGraphSearchTests.swift
+++ b/Tests/SwiftGraphTests/SwiftGraphSearchTests.swift
@@ -248,6 +248,29 @@ class SwiftGraphSearchTests: XCTestCase {
         XCTAssertEqual(visited, ["C", "B"])
     }
 
+    func testTraverseDfsOnCycle() {
+        let g = UnweightedGraph(withCycle: ["A", "B", "C"], directed: true)
+        let aIndex = g.indexOfVertex("A")!
+
+        // First vertex is not fed to the reducer
+        var visitedCound = 1
+        var visitLog = "A"
+
+        let finalVertexIndex = g.traverseDfs(fromIndex: aIndex,
+                                             goalTest: { _ in visitedCound == 3},
+                                             visitOrder: { $0 },
+                                             reducer: {
+                                                visitLog += g.vertexAtIndex($0.v)
+                                                if $0.v == aIndex {
+                                                    visitedCound += 1
+                                                }
+                                                return true
+                                             }
+        )
+        XCTAssertEqual(finalVertexIndex, aIndex, "The traversal must finish on vertex A")
+        XCTAssertEqual(visitLog, "ABCABCA", "The cycle must be traversed twice")
+    }
+
     func testFindAllDfs() {
         // New York -> all cities starting with "S"
         let result = cityGraph.findAllDfs(from: "New York") { v in
@@ -412,6 +435,29 @@ class SwiftGraphSearchTests: XCTestCase {
                   }
         )
         XCTAssertEqual(visited, ["B", "C"])
+    }
+
+    func testTraverseBfsOnCycle() {
+        let g = UnweightedGraph(withCycle: ["A", "B", "C"], directed: true)
+        let aIndex = g.indexOfVertex("A")!
+
+        // First vertex is not fed to the reducer
+        var visitedCound = 1
+        var visitLog = "A"
+
+        let finalVertexIndex = g.traverseBfs(fromIndex: aIndex,
+                                             goalTest: { _ in visitedCound == 3},
+                                             visitOrder: { $0 },
+                                             reducer: {
+                                                visitLog += g.vertexAtIndex($0.v)
+                                                if $0.v == aIndex {
+                                                    visitedCound += 1
+                                                }
+                                                return true
+        }
+        )
+        XCTAssertEqual(finalVertexIndex, aIndex, "The traversal must finish on vertex A")
+        XCTAssertEqual(visitLog, "ABCABCA", "The cycle must be traversed twice")
     }
     
     func testFindAllBfs() {


### PR DESCRIPTION
This versions of Dfs and Bfs do not care if vertices have been already visited. This allows for example to model a for loop as a graph of statements and use on of this methods to simulate the execution of it.