### PR TITLE
Container edges

### DIFF
--- a/Sources/SwiftGraph/ContainerEdge.swift
+++ b/Sources/SwiftGraph/ContainerEdge.swift
@@ -1,0 +1,51 @@
+//
+//  ContainerEdge.swift
+//  SwiftGraph
+//
+//  Copyright (c) 2019 Ferran Pujol Camins
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+
+/// An edge that holds an equatable type. Two edges are equal if and only if they have same nodes and value.
+public struct ContainerEdge<T: Equatable>: Edge, CustomStringConvertible {
+    typealias U = T
+    public var u: Int
+    public var v: Int
+    public var value: T
+
+    public init(u: Int, v: Int, value: T) {
+        self.u = u
+        self.v = v
+        self.value = value
+    }
+
+    // MARK: Operator Overloads
+    static public func ==(lhs: ContainerEdge, rhs: ContainerEdge) -> Bool {
+        return lhs.u == rhs.u && lhs.v == rhs.v && lhs.value == rhs.value
+    }
+}
+
+extension ContainerEdge {
+    // Implement Printable protocol
+    public var description: String {
+        return "\(u) -> \(v)"
+    }
+}
+
+extension ContainerEdge where T: CustomStringConvertible {
+    // Implement Printable protocol
+    public var description: String {
+        return "\(u) -[\(value)]-> \(v)"
+    }
+}

--- a/Sources/SwiftGraph/Edge.swift
+++ b/Sources/SwiftGraph/Edge.swift
@@ -17,16 +17,12 @@
 //  limitations under the License.
 
 /// A protocol that all edges in a graph must conform to.
-public protocol Edge: CustomStringConvertible {
+public protocol Edge: CustomStringConvertible, Equatable {
     /// The origin vertex of the edge
     var u: Int {get set}  //made modifiable for changing when removing vertices
     /// The destination vertex of the edge
     var v: Int {get set}  //made modifiable for changing when removing vertices
 }
 
-extension Edge where Self: Equatable {
-    //MARK: Operator Overloads
-    static public func ==(lhs: Self, rhs: Self) -> Bool {
-        return lhs.u == rhs.u && lhs.v == rhs.v
-    }
-}
+// Edges conforming this protocol can be searched in a graph only their start and end nodes.
+public protocol SearchableByNodes: Edge {}

--- a/Sources/SwiftGraph/Graph.swift
+++ b/Sources/SwiftGraph/Graph.swift
@@ -49,7 +49,6 @@ extension Graph {
     ///
     /// - parameter vertex: The vertex you are looking for.
     /// - returns: The index of the vertex. Return nil if it can't find it.
-    
     public func indexOfVertex(_ vertex: V) -> Int? {
         if let i = vertices.index(of: vertex) {
             return i
@@ -92,7 +91,11 @@ extension Graph {
         }
         return nil
     }
-    
+
+    public func edgeExists(_ edge: E) -> Bool {
+        return edgeExists(from: edge.u, to: edge.v)
+    }
+
     /// Is there an edge from one vertex to another?
     ///
     /// - parameter from: The index of the starting edge.

--- a/Sources/SwiftGraph/Graph.swift
+++ b/Sources/SwiftGraph/Graph.swift
@@ -21,7 +21,7 @@
 /// *UnweightedGraph* and *WeightedGraph*
 public protocol Graph: class, CustomStringConvertible, Collection {
     associatedtype V: Equatable
-    associatedtype E: Edge & Equatable
+    associatedtype E: Edge
     var vertices: [V] { get set }
     var edges: [[E]] { get set }
 }
@@ -90,33 +90,6 @@ extension Graph {
             return edgesForIndex(i)
         }
         return nil
-    }
-
-    public func edgeExists(_ edge: E) -> Bool {
-        return edgeExists(from: edge.u, to: edge.v)
-    }
-
-    /// Is there an edge from one vertex to another?
-    ///
-    /// - parameter from: The index of the starting edge.
-    /// - parameter to: The index of the ending edge.
-    /// - returns: A Bool that is true if such an edge exists, and false otherwise.
-    public func edgeExists(from: Int, to: Int) -> Bool {
-        return edges[from].map({$0.v}).contains(to)
-    }
-    
-    /// Is there an edge from one vertex to another? Note this will look at the first occurence of each vertex. Also returns false if either of the supplied vertices cannot be found in the graph.
-    ///
-    /// - parameter from: The first vertex.
-    /// - parameter to: The second vertex.
-    /// - returns: A Bool that is true if such an edge exists, and false otherwise.
-    public func edgeExists(from: V, to: V) -> Bool {
-        if let u = indexOfVertex(from) {
-            if let v = indexOfVertex(to) {
-                return edgeExists(from: u, to: v)
-            }
-        }
-        return false
     }
     
     /// Find the first occurence of a vertex.
@@ -270,3 +243,45 @@ extension Graph {
     }
 }
 
+extension Graph {
+    /// Returns true if the passed edge is in the grph.
+    ///
+    /// - parameter edge: The edge to find in the graph.
+    /// - returns: A Bool that is true if such an edge exists, and false otherwise.
+    public func edgeExists(_ edge: E) -> Bool {
+        return edges[edge.u].contains(edge)
+    }
+}
+
+extension Graph where E: SearchableByNodes {
+    /// Returns true if the passed edge is in the grph.
+    ///
+    /// - parameter edge: The edge to find in the graph.
+    /// - returns: A Bool that is true if such an edge exists, and false otherwise.
+    public func edgeExists(_ edge: E) -> Bool {
+        return edgeExists(from: edge.u, to: edge.v)
+    }
+
+    /// Is there an edge from one vertex to another?
+    ///
+    /// - parameter from: The index of the starting edge.
+    /// - parameter to: The index of the ending edge.
+    /// - returns: A Bool that is true if such an edge exists, and false otherwise.
+    public func edgeExists(from: Int, to: Int) -> Bool {
+        return edges[from].map({$0.v}).contains(to)
+    }
+
+    /// Is there an edge from one vertex to another? Note this will look at the first occurence of each vertex. Also returns false if either of the supplied vertices cannot be found in the graph.
+    ///
+    /// - parameter from: The first vertex.
+    /// - parameter to: The second vertex.
+    /// - returns: A Bool that is true if such an edge exists, and false otherwise.
+    public func edgeExists(from: V, to: V) -> Bool {
+        if let u = indexOfVertex(from) {
+            if let v = indexOfVertex(to) {
+                return edgeExists(from: u, to: v)
+            }
+        }
+        return false
+    }
+}

--- a/Sources/SwiftGraph/Search.swift
+++ b/Sources/SwiftGraph/Search.swift
@@ -144,7 +144,7 @@ public extension Graph {
             visited[v] = true
             if goalTest(vertexAtIndex(v)) {
                 // figure out route of edges based on pathDict
-                return pathDictToPath(from: fromIndex, to: v, pathDict: pathDict) as! [Self.E]
+                return pathDictToPath(from: fromIndex, to: v, pathDict: pathDict)
             }
             for e in edgesForIndex(v) {
                 if !visited[e.v] {
@@ -178,7 +178,7 @@ public extension Graph {
         // pretty standard dfs that doesn't visit anywhere twice; pathDict tracks route
         var visited: [Bool] = [Bool](repeating: false, count: vertexCount)
         let stack: Stack<Int> = Stack<Int>()
-        var pathDict: [Int: Edge] = [Int: Edge]()
+        var pathDict: [Int: E] = [Int: E]()
         stack.push(fromIndex)
         while !stack.isEmpty {
             let v: Int = stack.pop()
@@ -188,7 +188,7 @@ public extension Graph {
             visited[v] = true
             if v == toIndex {
                 // figure out route of edges based on pathDict
-                return pathDictToPath(from: fromIndex, to: toIndex, pathDict: pathDict) as! [Self.E]
+                return pathDictToPath(from: fromIndex, to: toIndex, pathDict: pathDict)
             }
             for e in edgesForIndex(v) {
                 if !visited[e.v] {
@@ -224,8 +224,8 @@ public extension Graph {
         // pretty standard bfs that doesn't visit anywhere twice; pathDict tracks route
         var visited: [Bool] = [Bool](repeating: false, count: vertexCount)
         let stack: Stack<Int> = Stack<Int>()
-        var pathDict: [Int: Edge] = [Int: Edge]()
-        var paths: [[Edge]] = [[Edge]]()
+        var pathDict: [Int: E] = [Int: E]()
+        var paths: [[E]] = [[E]]()
         stack.push(fromIndex)
         while !stack.isEmpty {
             let v: Int = stack.pop()
@@ -244,7 +244,7 @@ public extension Graph {
                 }
             }
         }
-        return paths as! [[Self.E]]
+        return paths
     }
 
     /// Find path routes from a vertex to all others the
@@ -372,13 +372,13 @@ public extension Graph {
         // pretty standard bfs that doesn't visit anywhere twice; pathDict tracks route
         var visited: [Bool] = [Bool](repeating: false, count: vertexCount)
         let queue: Queue<Int> = Queue<Int>()
-        var pathDict: [Int: Edge] = [Int: Edge]()
+        var pathDict: [Int: E] = [Int: E]()
         queue.push(fromIndex)
         while !queue.isEmpty {
             let v: Int = queue.pop()
             if goalTest(vertexAtIndex(v)) {
                 // figure out route of edges based on pathDict
-                return pathDictToPath(from: fromIndex, to: v, pathDict: pathDict) as! [Self.E]
+                return pathDictToPath(from: fromIndex, to: v, pathDict: pathDict)
             }
             
             for e in edgesForIndex(v) {
@@ -414,13 +414,13 @@ public extension Graph {
         // pretty standard bfs that doesn't visit anywhere twice; pathDict tracks route
         var visited: [Bool] = [Bool](repeating: false, count: vertexCount)
         let queue: Queue<Int> = Queue<Int>()
-        var pathDict: [Int: Edge] = [Int: Edge]()
+        var pathDict: [Int: E] = [Int: E]()
         queue.push(fromIndex)
         while !queue.isEmpty {
             let v: Int = queue.pop()
             if v == toIndex {
                 // figure out route of edges based on pathDict
-                return pathDictToPath(from: fromIndex, to: toIndex, pathDict: pathDict) as! [Self.E]
+                return pathDictToPath(from: fromIndex, to: toIndex, pathDict: pathDict)
             }
             
             for e in edgesForIndex(v) {
@@ -458,8 +458,8 @@ public extension Graph {
         // pretty standard bfs that doesn't visit anywhere twice; pathDict tracks route
         var visited: [Bool] = [Bool](repeating: false, count: vertexCount)
         let queue: Queue<Int> = Queue<Int>()
-        var pathDict: [Int: Edge] = [Int: Edge]()
-        var paths: [[Edge]] = [[Edge]]()
+        var pathDict: [Int: E] = [Int: E]()
+        var paths: [[E]] = [[E]]()
         queue.push(fromIndex)
         while !queue.isEmpty {
             let v: Int = queue.pop()
@@ -476,7 +476,7 @@ public extension Graph {
                 }
             }
         }
-        return paths as! [[Self.E]]
+        return paths
     }
     
     /// Find path routes from a vertex to all others the
@@ -579,12 +579,12 @@ extension Graph {
 
 /// Takes a dictionary of edges to reach each node and returns an array of edges
 /// that goes from `from` to `to`
-public func pathDictToPath(from: Int, to: Int, pathDict:[Int:Edge]) -> [Edge] {
+public func pathDictToPath<E: Edge>(from: Int, to: Int, pathDict: [Int: E]) -> [E] {
     if pathDict.count == 0 {
         return []
     }
-    var edgePath: [Edge] = [Edge]()
-    var e: Edge = pathDict[to]!
+    var edgePath: [E] = [E]()
+    var e: E = pathDict[to]!
     edgePath.append(e)
     while (e.u != from) {
         e = pathDict[e.u]!

--- a/Sources/SwiftGraph/Union.swift
+++ b/Sources/SwiftGraph/Union.swift
@@ -17,7 +17,7 @@
 //  limitations under the License.
 
 // MARK: - Extension to UniqueVerticesGraph with Union initializer
-public extension UniqueElementsGraph {
+public extension UniqueElementsGraphCustomEdge {
     
     /// Creates a new UniqueVerticesGraph that is the union of several UniqueVerticesGraphs.
     ///
@@ -29,7 +29,7 @@ public extension UniqueElementsGraph {
     ///
     /// - Parameters:
     ///   - graphs: Array of graphs to build the union from.
-    public convenience init(unionOf graphs: [UniqueElementsGraph<V>]) {
+    public convenience init(unionOf graphs: [UniqueElementsGraphCustomEdge]) {
         self.init()
 
         guard let firstGraph = graphs.first else { return }
@@ -53,13 +53,17 @@ public extension UniqueElementsGraph {
                 _ = addVertex(vertex)
             }
 
-            for edge in g.edges.joined() {
-                addEdge(from: g[edge.u], to: g[edge.v], directed: true)
+            for var edge in g.edges.joined() {
+                if let u = indexOfVertex(g[edge.u]), let v = indexOfVertex(g[edge.v]) {
+                    edge.u = u
+                    edge.v = v
+                    addEdge(edge)
+                }
             }
         }
     }
 
-    public convenience init(unionOf graphs: UniqueElementsGraph<V>...) {
+    public convenience init(unionOf graphs: UniqueElementsGraphCustomEdge...) {
         self.init(unionOf: graphs)
     }
 }

--- a/Sources/SwiftGraph/UniqueElementsGraph.swift
+++ b/Sources/SwiftGraph/UniqueElementsGraph.swift
@@ -18,7 +18,7 @@
 
 public typealias UniqueElementsGraph<V: Equatable> = UniqueElementsGraphCustomEdge<V, UnweightedEdge>
 
-/// A Grpah that ensures there are no pairs of equal vertices and no repeated edges.
+/// A Graph that ensures there are no pairs of equal vertices and no repeated edges.
 open class UniqueElementsGraphCustomEdge<V: Equatable, E: Edge&Equatable>: Graph {
     public var vertices: [V] = [V]()
     public var edges: [[E]] = [[E]]() //adjacency lists

--- a/Sources/SwiftGraph/UniqueElementsGraph.swift
+++ b/Sources/SwiftGraph/UniqueElementsGraph.swift
@@ -18,7 +18,7 @@
 
 typealias UniqueElementsGraph<V: Equatable> = UniqueElementsGraphCustomEdge<V, UnweightedEdge>
 
-/// A subclass of UnweightedGraph that ensures there are no pairs of equal vertices and no repeated edges.
+/// A Grpah that ensures there are no pairs of equal vertices and no repeated edges.
 open class UniqueElementsGraphCustomEdge<V: Equatable, E: Edge&Equatable>: Graph {
     public var vertices: [V] = [V]()
     public var edges: [[E]] = [[E]]() //adjacency lists
@@ -196,5 +196,63 @@ extension UniqueElementsGraphCustomEdge where V: Hashable, E == UnweightedEdge {
             }
         }
         return indices
+    }
+}
+
+// A UniqueElementsGraph with ContainerEdges.
+// Edges are only considered duplicates when they have the same start and end nodes and same value.
+// This means that there can be multiple edges between the same pair of vertices if the edges have different values.
+class UniqueElementsGraphContainerEdge<V: Equatable, Value: Equatable>: UniqueElementsGraphCustomEdge<V, ContainerEdge<Value>> {
+
+    /// This is a convenience method that adds a container edge.
+    ///
+    /// - parameter from: The starting vertex's index.
+    /// - parameter to: The ending vertex's index.
+    /// - parameter value: The value that will be associated to the edge
+    /// - parameter directed: Is the edge directed? (default `false`)
+    public func addEdge(fromIndex: Int, toIndex: Int, value: Value, directed: Bool = false) {
+        addEdge(ContainerEdge<Value>(u: fromIndex, v: toIndex, value: value))
+        if !directed {
+            addEdge(ContainerEdge<Value>(u: toIndex, v: fromIndex, value: value))
+        }
+
+    }
+
+    /// This is a convenience method that adds a container edge between the first occurence of two vertices. It takes O(n) time.
+    ///
+    /// - parameter from: The starting vertex.
+    /// - parameter to: The ending vertex.
+    /// - parameter value: The value that will be associated to the edge
+    /// - parameter directed: Is the edge directed? (default `false`)
+    public func addEdge(from: V, to: V, value: Value, directed: Bool = false) {
+        if let u = indexOfVertex(from), let v = indexOfVertex(to) {
+            addEdge(ContainerEdge<Value>(u: u, v: v, value: value))
+            if !directed {
+                addEdge(ContainerEdge<Value>(u: v, v: u, value: value))
+            }
+        }
+    }
+
+    /// Returns all the values associated to the edges between two vertex indices.
+    ///
+    /// - Parameters:
+    ///   - from: The starting vertex index
+    ///   - to: The ending vertex index
+    /// - Returns: An array with all the values associated to edges between the provided indexes.
+    public func values(from: Int, to: Int) -> [Value] {
+        return edges[from].filter { $0.v == to }.map { $0.value }
+    }
+
+    /// Returns all the values associated to the edges between two vertices.
+    ///
+    /// - Parameters:
+    ///   - from: The starting vertex
+    ///   - to: The ending vertex
+    /// - Returns: An array with all the values associated to edges between the provided vertices.
+    public func values(from: V, to: V) -> [Value] {
+        if let u = indexOfVertex(from), let v = indexOfVertex(to) {
+            return edges[u].filter { $0.v == v }.map { $0.value }
+        }
+        return []
     }
 }

--- a/Sources/SwiftGraph/UniqueElementsGraph.swift
+++ b/Sources/SwiftGraph/UniqueElementsGraph.swift
@@ -16,7 +16,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-typealias UniqueElementsGraph<V: Equatable> = UniqueElementsGraphCustomEdge<V, UnweightedEdge>
+public typealias UniqueElementsGraph<V: Equatable> = UniqueElementsGraphCustomEdge<V, UnweightedEdge>
 
 /// A Grpah that ensures there are no pairs of equal vertices and no repeated edges.
 open class UniqueElementsGraphCustomEdge<V: Equatable, E: Edge&Equatable>: Graph {

--- a/Sources/SwiftGraph/UniqueElementsGraph.swift
+++ b/Sources/SwiftGraph/UniqueElementsGraph.swift
@@ -16,10 +16,12 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+typealias UniqueElementsGraph<V: Equatable> = UniqueElementsGraphCustomEdge<V, UnweightedEdge>
+
 /// A subclass of UnweightedGraph that ensures there are no pairs of equal vertices and no repeated edges.
-open class UniqueElementsGraph<V: Equatable>: Graph {
+open class UniqueElementsGraphCustomEdge<V: Equatable, E: Edge&Equatable>: Graph {
     public var vertices: [V] = [V]()
-    public var edges: [[UnweightedEdge]] = [[UnweightedEdge]]() //adjacency lists
+    public var edges: [[E]] = [[E]]() //adjacency lists
 
     public init() {
     }
@@ -47,12 +49,14 @@ open class UniqueElementsGraph<V: Equatable>: Graph {
     /// Only allow the edge to be added once
     ///
     /// - parameter e: The edge to add.
-    public func addEdge(_ e: UnweightedEdge) {
+    public func addEdge(_ e: E) {
         if !edgeExists(e) {
             edges[e.u].append(e)
         }
     }
-    
+}
+
+extension UniqueElementsGraphCustomEdge where E == UnweightedEdge {
     /// Only allow the edge to be added once
     ///
     /// - parameter from: The starting vertex's index.
@@ -68,7 +72,7 @@ open class UniqueElementsGraph<V: Equatable>: Graph {
             }
         }
     }
-    
+
     /// Only allow the edge to be added once
     ///
     /// - parameter from: The starting vertex.
@@ -79,9 +83,6 @@ open class UniqueElementsGraph<V: Equatable>: Graph {
             addEdge(fromIndex: u, toIndex: v, directed: directed)
         }
     }
-}
-
-extension UniqueElementsGraph {
 
     private func addEdgesForPath(withIndices indices: [Int], directed: Bool) {
         for i in 0..<indices.count - 1 {
@@ -147,10 +148,9 @@ extension UniqueElementsGraph {
         addEdgesForPath(withIndices: indices, directed: directed)
         addEdge(fromIndex: indices.last!, toIndex: indices.first!, directed: directed)
     }
-
 }
 
-extension UniqueElementsGraph where V: Hashable {
+extension UniqueElementsGraphCustomEdge where V: Hashable, E == UnweightedEdge {
     public convenience init(withPath path: [V], directed: Bool = false) {
         self.init()
 

--- a/Sources/SwiftGraph/UniqueElementsGraph.swift
+++ b/Sources/SwiftGraph/UniqueElementsGraph.swift
@@ -48,7 +48,7 @@ open class UniqueElementsGraph<V: Equatable>: Graph {
     ///
     /// - parameter e: The edge to add.
     public func addEdge(_ e: UnweightedEdge) {
-        if !edgeExists(from: e.u, to: e.v) {
+        if !edgeExists(e) {
             edges[e.u].append(e)
         }
     }
@@ -59,10 +59,12 @@ open class UniqueElementsGraph<V: Equatable>: Graph {
     /// - parameter to: The ending vertex's index.
     /// - parameter directed: Is the edge directed? (default `false`)
     public func addEdge(fromIndex u: Int, toIndex v: Int, directed: Bool = false) {
-        if !edgeExists(from: u, to: v) {
-            addEdge(UnweightedEdge(u: u, v: v))
-            if !directed && !edgeExists(from: v, to: u) {
-                addEdge(UnweightedEdge(u: v, v: u))
+        let edge = UnweightedEdge(u: u, v: v)
+        if !edgeExists(edge) {
+            addEdge(edge)
+            let reverseEdge = UnweightedEdge(u: v, v: u)
+            if !directed && !edgeExists(reverseEdge) {
+                addEdge(reverseEdge)
             }
         }
     }

--- a/Sources/SwiftGraph/UnweightedEdge.swift
+++ b/Sources/SwiftGraph/UnweightedEdge.swift
@@ -17,7 +17,7 @@
 //  limitations under the License.
 
 /// A basic unweighted edge.
-public struct UnweightedEdge: Edge, CustomStringConvertible, Codable, Equatable {
+public struct UnweightedEdge: SearchableByNodes, CustomStringConvertible, Codable {
     public var u: Int
     public var v: Int
     
@@ -26,8 +26,13 @@ public struct UnweightedEdge: Edge, CustomStringConvertible, Codable, Equatable 
         self.v = v
     }
     
-    //Implement Printable protocol
+    // Implement Printable protocol
     public var description: String {
         return "\(u) -> \(v)"
+    }
+
+    // MARK: Operator Overloads
+    static public func ==(lhs: UnweightedEdge, rhs: UnweightedEdge) -> Bool {
+        return lhs.u == rhs.u && lhs.v == rhs.v
     }
 }

--- a/Sources/SwiftGraph/WeightedEdge.swift
+++ b/Sources/SwiftGraph/WeightedEdge.swift
@@ -18,7 +18,7 @@
 
 
 /// A weighted edge, who's weight subscribes to Comparable.
-public struct WeightedEdge<W: Comparable & Numeric & Codable>: Edge, CustomStringConvertible, Codable, Equatable, Comparable {
+public struct WeightedEdge<W: Comparable & Numeric & Codable>: SearchableByNodes, CustomStringConvertible, Codable, Comparable {
     public var u: Int
     public var v: Int
     public var weight: W
@@ -29,12 +29,12 @@ public struct WeightedEdge<W: Comparable & Numeric & Codable>: Edge, CustomStrin
         self.weight = weight
     }
 
-    //Implement Printable protocol
+    // Implement Printable protocol
     public var description: String {
         return "\(u) \(weight)> \(v)"
     }
     
-    //MARK: Operator Overloads
+    // MARK: Operator Overloads
     static public func == <W>(lhs: WeightedEdge<W>, rhs: WeightedEdge<W>) -> Bool {
         return lhs.u == rhs.u && lhs.v == rhs.v && lhs.weight == rhs.weight
     }

--- a/SwiftGraph.xcodeproj/project.pbxproj
+++ b/SwiftGraph.xcodeproj/project.pbxproj
@@ -39,6 +39,9 @@
 		B523F2EA2094F0E2006587ED /* UniqueElementsGraphHashableInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B523F2E92094F0E2006587ED /* UniqueElementsGraphHashableInitTests.swift */; };
 		B52ABD39208955BD00FBF10C /* UnionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52ABD37208955B500FBF10C /* UnionTests.swift */; };
 		B52C867B222DC89400CF6B49 /* UnionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52C867A222DC89400CF6B49 /* UnionTests.swift */; };
+		B52C867D222DD18500CF6B49 /* ContainerEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52C867C222DD18500CF6B49 /* ContainerEdge.swift */; };
+		B52C867F222DD5F700CF6B49 /* UniqueElementsGraphContainerEdgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52C867E222DD5F700CF6B49 /* UniqueElementsGraphContainerEdgeTests.swift */; };
+		B52C8681222DD9F800CF6B49 /* ArrayHasSameElements.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52C8680222DD9F800CF6B49 /* ArrayHasSameElements.swift */; };
 		B54FDA6E21729EFF00057C51 /* Constructors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54FDA6D21729EFF00057C51 /* Constructors.swift */; };
 		B54FDA712172A34D00057C51 /* ConstructorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54FDA702172A34D00057C51 /* ConstructorsTests.swift */; };
 		B5D022B1217357480079F17C /* ConstructorsPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D022B0217357480079F17C /* ConstructorsPerformanceTests.swift */; };
@@ -125,6 +128,9 @@
 		B523F2E92094F0E2006587ED /* UniqueElementsGraphHashableInitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniqueElementsGraphHashableInitTests.swift; sourceTree = "<group>"; };
 		B52ABD37208955B500FBF10C /* UnionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnionTests.swift; sourceTree = "<group>"; };
 		B52C867A222DC89400CF6B49 /* UnionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionTests.swift; sourceTree = "<group>"; };
+		B52C867C222DD18500CF6B49 /* ContainerEdge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ContainerEdge.swift; path = Sources/SwiftGraph/ContainerEdge.swift; sourceTree = SOURCE_ROOT; };
+		B52C867E222DD5F700CF6B49 /* UniqueElementsGraphContainerEdgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniqueElementsGraphContainerEdgeTests.swift; sourceTree = "<group>"; };
+		B52C8680222DD9F800CF6B49 /* ArrayHasSameElements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayHasSameElements.swift; sourceTree = "<group>"; };
 		B54FDA6D21729EFF00057C51 /* Constructors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Constructors.swift; path = ../Sources/SwiftGraph/Constructors.swift; sourceTree = "<group>"; };
 		B54FDA702172A34D00057C51 /* ConstructorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstructorsTests.swift; sourceTree = "<group>"; };
 		B5D022B0217357480079F17C /* ConstructorsPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstructorsPerformanceTests.swift; sourceTree = "<group>"; };
@@ -177,6 +183,7 @@
 			children = (
 				5589B4621C0E72CC00D6664E /* Edge.swift */,
 				5589B4651C0E734F00D6664E /* UnweightedEdge.swift */,
+				B52C867C222DD18500CF6B49 /* ContainerEdge.swift */,
 				5589B4681C0E74CD00D6664E /* WeightedEdge.swift */,
 			);
 			name = Edges;
@@ -293,6 +300,7 @@
 				B5EF143221791348008FCC5C /* UniqueElementsGraphHashableTests.swift */,
 				B5EF143021791009008FCC5C /* UniqueElementsGraphInitTests.swift */,
 				B523F2E92094F0E2006587ED /* UniqueElementsGraphHashableInitTests.swift */,
+				B52C867E222DD5F700CF6B49 /* UniqueElementsGraphContainerEdgeTests.swift */,
 			);
 			path = UniqueElementsGraph;
 			sourceTree = "<group>";
@@ -328,6 +336,7 @@
 			isa = PBXGroup;
 			children = (
 				B5EF1436217913F1008FCC5C /* EquatableTypes.swift */,
+				B52C8680222DD9F800CF6B49 /* ArrayHasSameElements.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -527,6 +536,7 @@
 				7985B92A1E5A503200C100E7 /* Stack.swift in Sources */,
 				7985B9281E5A503200C100E7 /* Search.swift in Sources */,
 				7985B9211E5A503200C100E7 /* Edge.swift in Sources */,
+				B52C867D222DD18500CF6B49 /* ContainerEdge.swift in Sources */,
 				7985B9271E5A503200C100E7 /* SwiftPriorityQueue.swift in Sources */,
 				55DCCBF61F8ADA12001913F7 /* Cycle.swift in Sources */,
 			);
@@ -543,6 +553,8 @@
 				55E784281ED2971E003899D0 /* MSTTests.swift in Sources */,
 				B5100A4D208B97AA00C7A73A /* UnweightedGraphTests.swift in Sources */,
 				B5EF1437217913F1008FCC5C /* EquatableTypes.swift in Sources */,
+				B52C867F222DD5F700CF6B49 /* UniqueElementsGraphContainerEdgeTests.swift in Sources */,
+				B52C8681222DD9F800CF6B49 /* ArrayHasSameElements.swift in Sources */,
 				7985B91D1E5A4FCB00C100E7 /* DijkstraGraphTests.swift in Sources */,
 				7985B91F1E5A4FCB00C100E7 /* SwiftGraphSortTests.swift in Sources */,
 				B5EF143321791348008FCC5C /* UniqueElementsGraphHashableTests.swift in Sources */,

--- a/SwiftGraph.xcodeproj/project.pbxproj
+++ b/SwiftGraph.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		B51B460B2083E14200CD0463 /* Union.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51B460A2083E14200CD0463 /* Union.swift */; };
 		B523F2EA2094F0E2006587ED /* UniqueElementsGraphHashableInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B523F2E92094F0E2006587ED /* UniqueElementsGraphHashableInitTests.swift */; };
 		B52ABD39208955BD00FBF10C /* UnionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52ABD37208955B500FBF10C /* UnionTests.swift */; };
+		B52C867B222DC89400CF6B49 /* UnionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52C867A222DC89400CF6B49 /* UnionTests.swift */; };
 		B54FDA6E21729EFF00057C51 /* Constructors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54FDA6D21729EFF00057C51 /* Constructors.swift */; };
 		B54FDA712172A34D00057C51 /* ConstructorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54FDA702172A34D00057C51 /* ConstructorsTests.swift */; };
 		B5D022B1217357480079F17C /* ConstructorsPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D022B0217357480079F17C /* ConstructorsPerformanceTests.swift */; };
@@ -123,6 +124,7 @@
 		B51B460A2083E14200CD0463 /* Union.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Union.swift; path = ../Sources/SwiftGraph/Union.swift; sourceTree = "<group>"; };
 		B523F2E92094F0E2006587ED /* UniqueElementsGraphHashableInitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniqueElementsGraphHashableInitTests.swift; sourceTree = "<group>"; };
 		B52ABD37208955B500FBF10C /* UnionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnionTests.swift; sourceTree = "<group>"; };
+		B52C867A222DC89400CF6B49 /* UnionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionTests.swift; sourceTree = "<group>"; };
 		B54FDA6D21729EFF00057C51 /* Constructors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Constructors.swift; path = ../Sources/SwiftGraph/Constructors.swift; sourceTree = "<group>"; };
 		B54FDA702172A34D00057C51 /* ConstructorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstructorsTests.swift; sourceTree = "<group>"; };
 		B5D022B0217357480079F17C /* ConstructorsPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstructorsPerformanceTests.swift; sourceTree = "<group>"; };
@@ -316,6 +318,7 @@
 			children = (
 				B5DD6DA42171EEE1007EFF44 /* SearchPerformanceTests.swift */,
 				B5D022B0217357480079F17C /* ConstructorsPerformanceTests.swift */,
+				B52C867A222DC89400CF6B49 /* UnionTests.swift */,
 			);
 			name = SwiftGraphPerformanceTests;
 			path = Tests/SwiftGraphPerformanceTests;
@@ -555,6 +558,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B52C867B222DC89400CF6B49 /* UnionTests.swift in Sources */,
 				B5EACB292172336900E527BD /* SearchPerformanceTests.swift in Sources */,
 				B5D022B1217357480079F17C /* ConstructorsPerformanceTests.swift in Sources */,
 			);

--- a/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/94D648AC-76B2-4B8F-A1FF-3A34FAC1AF9B.plist
+++ b/SwiftGraph.xcodeproj/xcshareddata/xcbaselines/B5EACB0A2172315E00E527BD.xcbaseline/94D648AC-76B2-4B8F-A1FF-3A34FAC1AF9B.plist
@@ -330,6 +330,29 @@
 				</dict>
 			</dict>
 		</dict>
+		<key>UnionTests</key>
+		<dict>
+			<key>testDisjointUnion()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.89682</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testUnionWithSelf()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.90371</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/Tests/SwiftGraphPerformanceTests/ConstructorsPerformanceTests.swift
+++ b/Tests/SwiftGraphPerformanceTests/ConstructorsPerformanceTests.swift
@@ -40,13 +40,13 @@ class ConstructorsPerformanceTests: XCTestCase {
     func testPathUniqueElementsGraphConstructor() {
         let array = Array(1...2999).map({ AnyEquatable(value: $0) })
         self.measure {
-            _ = UniqueElementsGraph<AnyEquatable>(withPath: array)
+            _ = UniqueElementsGraph(withPath: array)
         }
     }
 
     func testPathUniqueElementsGraphHashableConstructor() {
         self.measure {
-            _ = UniqueElementsGraph<Int>(withPath: Array(1...2999))
+            _ = UniqueElementsGraph(withPath: Array(1...2999))
         }
     }
 

--- a/Tests/SwiftGraphPerformanceTests/UnionTests.swift
+++ b/Tests/SwiftGraphPerformanceTests/UnionTests.swift
@@ -1,0 +1,38 @@
+//
+//  ConstructorsPerformanceTests.swift
+//  SwiftGraphTests
+//
+//  Copyright (c) 2018 Ferran Pujol Camins
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import XCTest
+@testable import SwiftGraph
+
+class UnionTests: XCTestCase {
+
+    func testDisjointUnion() {
+        let g1 = UniqueElementsGraph<Int>(withPath: Array(1...999))
+        let g2 = UniqueElementsGraph<Int>(withPath: Array(1000...1999))
+        self.measure {
+            _ = UniqueElementsGraph<Int>(unionOf: g1, g2)
+        }
+    }
+
+    func testUnionWithSelf() {
+        let g = UniqueElementsGraph<Int>(withPath: Array(1...999))
+        self.measure {
+            _ = UniqueElementsGraph<Int>(unionOf: g, g, g, g)
+        }
+    }
+}

--- a/Tests/SwiftGraphTests/UnionTests.swift
+++ b/Tests/SwiftGraphTests/UnionTests.swift
@@ -177,17 +177,4 @@ class UnionTests: XCTestCase {
         XCTAssertTrue(g.edgeExists(from: "B", to: "C"), "g: Expected an edge from B to C")
         XCTAssertTrue(g.edgeExists(from: "C", to: "A"), "g: Expected an edge from C to A")
     }
-
-    func arraysHaveSameElements<T: Equatable>(_ a1: [T], _ a2: [T]) -> Bool {
-        guard a1.count == a2.count else {
-            return false
-        }
-
-        for e in a1 {
-            if !a2.contains(e) {
-                return false
-            }
-        }
-        return true
-    }
 }

--- a/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphContainerEdgeTests.swift
+++ b/Tests/SwiftGraphTests/UniqueElementsGraph/UniqueElementsGraphContainerEdgeTests.swift
@@ -1,0 +1,43 @@
+//
+//  UniqueElementsGraphContainerEdgeTests.swift
+//  SwiftGraph
+//
+//  Copyright (c) 2019 Ferran Pujol Camins
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import XCTest
+@testable import SwiftGraph
+
+class UniqueElementsGraphContainerEdgeTests: XCTestCase {
+
+    func testExample() {
+        let g = UniqueElementsGraphContainerEdge<String, String>(
+            vertices: ["A", "B", "C"]
+        )
+        g.addEdge(ContainerEdge<String>(u: 0, v: 1, value: "AB"))
+        g.addEdge(ContainerEdge<String>(u: 1, v: 2, value: "BC"))
+        g.addEdge(ContainerEdge<String>(u: 0, v: 1, value: "AB2"))
+        g.addEdge(ContainerEdge<String>(u: 1, v: 2, value: "BC"))
+
+        XCTAssertEqual(g.edgeCount, 3, "Wrong number of edges.")
+        XCTAssertTrue(arraysHaveSameElements(
+            g.values(from: 0, to: 1),
+            ["AB", "AB2"]
+        ), "Edges from same vertices but different value must both be in the union.")
+        XCTAssertTrue(arraysHaveSameElements(
+            g.values(from: 1, to: 2),
+            ["BC"]
+        ), "Duplicated edge 'BC' must appear only once.")
+    }
+}

--- a/Tests/SwiftGraphTests/Utils/ArrayHasSameElements.swift
+++ b/Tests/SwiftGraphTests/Utils/ArrayHasSameElements.swift
@@ -1,0 +1,33 @@
+//
+//  ArrayHasSameElements.swift
+//  SwiftGraph
+//
+//  Copyright (c) 2019 Ferran Pujol Camins
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import Foundation
+
+// Returns true if both arrays have the same elements with the same number, regardless of the order.
+func arraysHaveSameElements<T: Equatable>(_ a1: [T], _ a2: [T]) -> Bool {
+    guard a1.count == a2.count else {
+        return false
+    }
+
+    for e in a1 {
+        if !a2.contains(e) {
+            return false
+        }
+    }
+    return true
+}


### PR DESCRIPTION
This PR introduces a new type of edge that holds a value of an arbitrary type.
I've have created UniqueElementsGraphContainerEdge, a subclass of UniqueElementsGraph to work with such edges. I also made some renaming so we don't need to specify the edge type all the time when we just want a UniqueElementsGraph with unweighted edges.

A similar class just conforming to Graph could also be implemented. So far I just implemented this for UniqueElementsGraph because is what I need, and I wanted to know your opinion before spending more time on this.

My particular use case is to model a state machine. The associated values on the edges are tuples made up by the event that triggers a transition of state and the side-effect that should be executed on the transition.

There's no performance hit in almost all test cases. Some of the search test cases seem to suffer a performance decrease of 6-7%.