### PR TITLE
Edge list

### DIFF
--- a/Sources/SwiftGraph/Edge.swift
+++ b/Sources/SwiftGraph/Edge.swift
@@ -22,7 +22,7 @@ public protocol Edge: CustomStringConvertible {
     var u: Int {get set}  //made modifiable for changing when removing vertices
     /// The destination vertex of the edge
     var v: Int {get set}  //made modifiable for changing when removing vertices
-
+    var directed: Bool { get set }
     // Returns an edge with the origin and destination reversed
     func reversed() -> Self
 }

--- a/Sources/SwiftGraph/Graph.swift
+++ b/Sources/SwiftGraph/Graph.swift
@@ -39,6 +39,24 @@ extension Graph {
     public var edgeCount: Int {
         return edges.joined().count
     }
+
+    /// Returns a list of all the edges, undirected edges are only appended once.
+    public func edgeList() -> [E] {
+        var edges = self.edges
+        var edgeList = [E]()
+        for i in edges.indices {
+            let edgesForVertex = edges[i]
+            for j in edgesForVertex.indices {
+                let edge = edgesForVertex[j]
+                // We only want to append undirected edges once, so we do it when we find it on the
+                // vertex with lowest index.
+                if edge.directed || edge.v >= edge.u {
+                    edgeList.append(edge)
+                }
+            }
+        }
+        return edgeList
+    }
     
     /// Get a vertex by its index.
     ///
@@ -124,7 +142,7 @@ extension Graph {
     ///                       Default is false.
     public func addEdge(_ e: E, directed: Bool = false) {
         edges[e.u].append(e)
-        if !directed {
+        if !directed && e.u != e.v {
             edges[e.v].append(e.reversed())
         }
     }

--- a/Sources/SwiftGraph/UnweightedEdge.swift
+++ b/Sources/SwiftGraph/UnweightedEdge.swift
@@ -20,14 +20,16 @@
 public struct UnweightedEdge: Edge, CustomStringConvertible, Codable, Equatable {
     public var u: Int
     public var v: Int
+    public var directed: Bool
     
-    public init(u: Int, v: Int) {
+    public init(u: Int, v: Int, directed: Bool) {
         self.u = u
         self.v = v
+        self.directed = directed
     }
 
     public func reversed() -> UnweightedEdge {
-        return UnweightedEdge(u: v, v: u)
+        return UnweightedEdge(u: v, v: u, directed: directed)
     }
 
     // Implement Printable protocol

--- a/Sources/SwiftGraph/UnweightedGraph.swift
+++ b/Sources/SwiftGraph/UnweightedGraph.swift
@@ -107,6 +107,8 @@ extension Graph where E == UnweightedEdge {
     /// - parameter to: The index of the ending vertex of the edge.
     /// - returns: True if there is an edge from the starting vertex to the ending vertex.
     public func edgeExists(fromIndex: Int, toIndex: Int) -> Bool {
+        // The directed property of this fake edge is ignored, since it's not taken into account
+        // for equality.
         return edgeExists(E(u: fromIndex, v: toIndex, directed: true))
     }
 

--- a/Sources/SwiftGraph/UnweightedGraph.swift
+++ b/Sources/SwiftGraph/UnweightedGraph.swift
@@ -87,7 +87,7 @@ extension Graph where E == UnweightedEdge {
     /// - parameter to: The ending vertex's index.
     /// - parameter directed: Is the edge directed? (default `false`)
     public func addEdge(fromIndex: Int, toIndex: Int, directed: Bool = false) {
-        addEdge(UnweightedEdge(u: fromIndex, v: toIndex), directed: directed)
+        addEdge(UnweightedEdge(u: fromIndex, v: toIndex, directed: directed), directed: directed)
     }
     
     /// This is a convenience method that adds an unweighted, undirected edge between the first occurence of two vertices. It takes O(n) time.
@@ -97,7 +97,7 @@ extension Graph where E == UnweightedEdge {
     /// - parameter directed: Is the edge directed? (default `false`)
     public func addEdge(from: V, to: V, directed: Bool = false) {
         if let u = indexOfVertex(from), let v = indexOfVertex(to) {
-            addEdge(UnweightedEdge(u: u, v: v), directed: directed)
+            addEdge(UnweightedEdge(u: u, v: v, directed: directed), directed: directed)
         }
     }
 
@@ -107,7 +107,7 @@ extension Graph where E == UnweightedEdge {
     /// - parameter to: The index of the ending vertex of the edge.
     /// - returns: True if there is an edge from the starting vertex to the ending vertex.
     public func edgeExists(fromIndex: Int, toIndex: Int) -> Bool {
-        return edgeExists(E(u: fromIndex, v: toIndex))
+        return edgeExists(E(u: fromIndex, v: toIndex, directed: true))
     }
 
     /// Check whether there is an edge from one vertex to another vertex.

--- a/Sources/SwiftGraph/WeightedEdge.swift
+++ b/Sources/SwiftGraph/WeightedEdge.swift
@@ -20,7 +20,7 @@
 public protocol WeightedEdgeProtocol {
     associatedtype Weight: Equatable
 
-    init(u: Int, v: Int, weight: Weight)
+    init(u: Int, v: Int, directed:Bool, weight: Weight)
     var weight: Weight { get }
 }
 
@@ -32,16 +32,18 @@ extension WeightedEdge: WeightedEdgeProtocol {
 public struct WeightedEdge<W: Equatable>: Edge, CustomStringConvertible, Equatable {
     public var u: Int
     public var v: Int
+    public var directed: Bool
     public var weight: W
     
-    public init(u: Int, v: Int, weight: W) {
+    public init(u: Int, v: Int, directed: Bool, weight: W) {
         self.u = u
         self.v = v
+        self.directed = directed
         self.weight = weight
     }
 
     public func reversed() -> WeightedEdge<W> {
-        return WeightedEdge(u: v, v: u, weight: weight)
+        return WeightedEdge(u: v, v: u, directed: directed, weight: weight)
     }
 
     //Implement Printable protocol

--- a/Sources/SwiftGraph/WeightedGraph.swift
+++ b/Sources/SwiftGraph/WeightedGraph.swift
@@ -74,6 +74,8 @@ extension Graph where E: WeightedEdgeProtocol {
     /// - parameter to: The index of the ending vertex of the edge.
     /// - returns: True if there is an edge from the starting vertex to the ending vertex.
     public func edgeExists(fromIndex: Int, toIndex: Int, withWeight weight: W) -> Bool {
+        // The directed property of this fake edge is ignored, since it's not taken into account
+        // for equality.
         return edgeExists(E(u: fromIndex, v: toIndex, directed: true, weight: weight))
     }
 

--- a/Sources/SwiftGraph/WeightedGraph.swift
+++ b/Sources/SwiftGraph/WeightedGraph.swift
@@ -53,7 +53,7 @@ extension Graph where E: WeightedEdgeProtocol {
     /// - parameter directed: Is the edge directed? (default false)
     /// - parameter weight: the Weight of the edge to add.
     public func addEdge(fromIndex: Int, toIndex: Int, weight: W, directed: Bool = false) {
-        addEdge(E(u: fromIndex, v: toIndex, weight: weight), directed: directed)
+        addEdge(E(u: fromIndex, v: toIndex, directed: directed, weight: weight), directed: directed)
     }
     
     /// This is a convenience method that adds a weighted edge between the first occurence of two vertices. It takes O(n) time.
@@ -74,7 +74,7 @@ extension Graph where E: WeightedEdgeProtocol {
     /// - parameter to: The index of the ending vertex of the edge.
     /// - returns: True if there is an edge from the starting vertex to the ending vertex.
     public func edgeExists(fromIndex: Int, toIndex: Int, withWeight weight: W) -> Bool {
-        return edgeExists(E(u: fromIndex, v: toIndex, weight: weight))
+        return edgeExists(E(u: fromIndex, v: toIndex, directed: true, weight: weight))
     }
 
     /// Check whether there is an edge from one vertex to another vertex with a specific weight.

--- a/SwiftGraph.xcodeproj/project.pbxproj
+++ b/SwiftGraph.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		B5D022B1217357480079F17C /* ConstructorsPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D022B0217357480079F17C /* ConstructorsPerformanceTests.swift */; };
 		B5D229BC207BF30100151820 /* UniqueElementsGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D229BB207BF30100151820 /* UniqueElementsGraph.swift */; };
 		B5D229BF207BF3A800151820 /* UniqueElementsGraphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D229BD207BF36900151820 /* UniqueElementsGraphTests.swift */; };
+		B5DEA65B223C4BC90005392F /* EdgeListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DEA65A223C4BC90005392F /* EdgeListTests.swift */; };
 		B5EACB1D2172315E00E527BD /* SwiftGraph.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7985B8FB1E5A4FB800C100E7 /* SwiftGraph.framework */; };
 		B5EACB292172336900E527BD /* SearchPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DD6DA42171EEE1007EFF44 /* SearchPerformanceTests.swift */; };
 		B5EF143121791009008FCC5C /* UniqueElementsGraphInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EF143021791009008FCC5C /* UniqueElementsGraphInitTests.swift */; };
@@ -134,6 +135,7 @@
 		B5D229BB207BF30100151820 /* UniqueElementsGraph.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UniqueElementsGraph.swift; path = Sources/SwiftGraph/UniqueElementsGraph.swift; sourceTree = SOURCE_ROOT; };
 		B5D229BD207BF36900151820 /* UniqueElementsGraphTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniqueElementsGraphTests.swift; sourceTree = "<group>"; };
 		B5DD6DA42171EEE1007EFF44 /* SearchPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPerformanceTests.swift; sourceTree = "<group>"; };
+		B5DEA65A223C4BC90005392F /* EdgeListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeListTests.swift; sourceTree = "<group>"; };
 		B5EACB222172315E00E527BD /* SwiftGraphPerformanceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftGraphPerformanceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5EF143021791009008FCC5C /* UniqueElementsGraphInitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniqueElementsGraphInitTests.swift; sourceTree = "<group>"; };
 		B5EF143221791348008FCC5C /* UniqueElementsGraphHashableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniqueElementsGraphHashableTests.swift; sourceTree = "<group>"; };
@@ -288,6 +290,7 @@
 				B52ABD37208955B500FBF10C /* UnionTests.swift */,
 				55F5EA5A2151E33100DFC301 /* SwiftGraphCodableTests.swift */,
 				B5F07B6C222EB4BD00824F08 /* WeightedGraphTests.swift */,
+				B5DEA65A223C4BC90005392F /* EdgeListTests.swift */,
 			);
 			name = SwiftGraphTests;
 			path = Tests/SwiftGraphTests;
@@ -545,6 +548,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B5DEA65B223C4BC90005392F /* EdgeListTests.swift in Sources */,
 				B5F07B6B222EB43000824F08 /* ArraysHaveSameElements.swift in Sources */,
 				7985B9201E5A4FCB00C100E7 /* SwiftGraphTests.swift in Sources */,
 				7985B91E1E5A4FCB00C100E7 /* SwiftGraphSearchTests.swift in Sources */,

--- a/Tests/SwiftGraphTests/EdgeListTests.swift
+++ b/Tests/SwiftGraphTests/EdgeListTests.swift
@@ -1,0 +1,120 @@
+//
+//  UnionTests.swift
+//  SwiftGraph
+//
+//  Copyright (c) 2019 Ferran Pujol Camins
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import XCTest
+import SwiftGraph
+
+class EdgeListTests: XCTestCase {
+
+    func testSingleDirectedEdgeList() {
+        let g = UnweightedGraph(vertices: ["A", "B"])
+        g.addEdge(from: "A", to: "B", directed: true)
+        XCTAssertEqual(g.edgeList(), [UnweightedEdge(u: 0, v: 1, directed: true)])
+    }
+
+    func testSingleDirectedLoopList() {
+        let g = UnweightedGraph(vertices: ["A"])
+        g.addEdge(from: "A", to: "A", directed: true)
+        XCTAssertEqual(g.edgeList(), [UnweightedEdge(u: 0, v: 0, directed: true)])
+    }
+
+    func testSingleUndirectedEdgeList() {
+        let g = UnweightedGraph(vertices: ["A", "B"])
+        g.addEdge(from: "A", to: "B", directed: false)
+        XCTAssertEqual(g.edgeList(), [UnweightedEdge(u: 0, v: 1, directed: false)])
+    }
+
+    func testSingleUndirectedLoopList() {
+        let g = UnweightedGraph(vertices: ["A"])
+        g.addEdge(from: "A", to: "A", directed: false)
+        XCTAssertEqual(g.edgeList(), [UnweightedEdge(u: 0, v: 0, directed: false)])
+    }
+
+    func testDirectedAndUndirectedEdges() {
+        let g = UnweightedGraph(vertices: ["A", "B"])
+        g.addEdge(from: "A", to: "B", directed: true)
+        g.addEdge(from: "A", to: "B", directed: false)
+        XCTAssertEqual(g.edgeList(), [
+            UnweightedEdge(u: 0, v: 1, directed: true),
+            UnweightedEdge(u: 0, v: 1, directed: false)
+        ])
+    }
+
+    func testDirectedAndUndirectedLoops() {
+        let g = UnweightedGraph(vertices: ["A"])
+        g.addEdge(from: "A", to: "A", directed: true)
+        g.addEdge(from: "A", to: "A", directed: false)
+        XCTAssertEqual(g.edgeList(), [
+            UnweightedEdge(u: 0, v: 0, directed: true),
+            UnweightedEdge(u: 0, v: 0, directed: false)
+        ])
+    }
+
+    func testTwoDirectedEdges() {
+        let g = UnweightedGraph(vertices: ["A", "B"])
+        g.addEdge(from: "A", to: "B", directed: true)
+        g.addEdge(from: "A", to: "B", directed: true)
+        XCTAssertEqual(g.edgeList(), [
+            UnweightedEdge(u: 0, v: 1, directed: true),
+            UnweightedEdge(u: 0, v: 1, directed: true)
+        ])
+
+        let g2 = UnweightedGraph(vertices: ["A", "B"])
+        g2.addEdge(from: "A", to: "B", directed: true)
+        g2.addEdge(from: "B", to: "A", directed: true)
+        XCTAssertEqual(g2.edgeList(), [
+            UnweightedEdge(u: 0, v: 1, directed: true),
+            UnweightedEdge(u: 1, v: 0, directed: true)
+        ])
+    }
+
+    func testTwoDirectedLoops() {
+        let g = UnweightedGraph(vertices: ["A"])
+        g.addEdge(from: "A", to: "A", directed: true)
+        g.addEdge(from: "A", to: "A", directed: true)
+        XCTAssertEqual(g.edgeList(), [
+            UnweightedEdge(u: 0, v: 0, directed: true),
+            UnweightedEdge(u: 0, v: 0, directed: true)
+        ])
+    }
+
+    func testTwoUndirectedEdges() {
+        let g = UnweightedGraph(vertices: ["A", "B"])
+        g.addEdge(from: "A", to: "B", directed: false)
+        g.addEdge(from: "A", to: "B", directed: false)
+        XCTAssertEqual(g.edgeList(), [
+            UnweightedEdge(u: 0, v: 1, directed: false),
+            UnweightedEdge(u: 0, v: 1, directed: false)
+        ])
+    }
+
+    func testTwoUndirectedLoops() {
+        let g = UnweightedGraph(vertices: ["A"])
+        g.addEdge(from: "A", to: "A", directed: false)
+        g.addEdge(from: "A", to: "A", directed: false)
+        XCTAssertEqual(g.edgeList(), [
+            UnweightedEdge(u: 0, v: 0, directed: false),
+            UnweightedEdge(u: 0, v: 0, directed: false)
+        ])
+    }
+
+    func testCompleteGraph() {
+        let g = CompleteGraph.build(withVertices: ["A", "B", "C", "D"])
+        XCTAssertEqual(g.edgeList().count, 6)
+    }
+}

--- a/Tests/SwiftGraphTests/SwiftGraphCodableTests.swift
+++ b/Tests/SwiftGraphTests/SwiftGraphCodableTests.swift
@@ -33,7 +33,7 @@ class SwiftGraphCodableTests: XCTestCase {
     }
     
     let expectedString = """
-     {"edges":[[{"u":0,"v":1}],[{"u":1,"v":0}]],"vertices":["New York","Miami"]}
+     {"edges":[[{"u":0,"v":1,"directed":false}],[{"u":1,"v":0,"directed":false}]],"vertices":["New York","Miami"]}
      """
     
     func testEncodableDecodable() {

--- a/Tests/SwiftGraphTests/UnweightedGraphTests.swift
+++ b/Tests/SwiftGraphTests/UnweightedGraphTests.swift
@@ -82,7 +82,7 @@ class UnweightedGraphTests: XCTestCase {
 
         let g1Cycle = UnweightedGraph(withCycle:["Atlanta"])
         XCTAssertEqual(g1Cycle.vertices, ["Atlanta"], "g1Cycle: Expected only Atlanta vertex")
-        XCTAssertEqual(g1Cycle.edgeCount, 2, "g1Cycle: Expected 2 edges")
+        XCTAssertEqual(g1Cycle.edgeCount, 1, "g1Cycle: Expected 1 edge")
         XCTAssertTrue(g1Cycle.edgeExists(from: "Atlanta", to: "Atlanta"), "g1Cycle: Expected an edge from Atlanta to Atlanta")
 
         let g2Cycle = UnweightedGraph(withCycle:["Atlanta", "Boston"])


### PR DESCRIPTION
In this PR I added a `directed`property to edges. I also added a new `edgeList()` method to Graph that returns a list of edges, but does not return the undirected edges twice (as opposed to `edges.joined()`).

With this changes we will be able to export graphs to DOT format for Graphviz.

I also changed the way undirected loops (edges starting and ending at the same vertex) are represented. Before, they were represented with two edges, like all other undirected edges. Now they are represented with a single edge, like we already were doing in UniqueElementsGraph.
This change was necessary to implement `edgeList()` efficiently, but also makes all the types of graph consistent in the way they represent undirected loops.