### PR TITLE
Improve performance of topological sort

### DIFF
--- a/Sources/SwiftGraph/Sort.swift
+++ b/Sources/SwiftGraph/Sort.swift
@@ -29,21 +29,27 @@ public extension Graph {
     /// - returns: the sorted vertices, or nil if the graph cannot be sorted due to not being a DAG
     func topologicalSort() -> [V]? {
         var sortedVertices = [V]()
-        let tsNodes = vertices.map{ TSNode<V>(vertex: $0, color: .white) }
+        let rangeOfVertices = 0..<vertexCount
+        let tsNodes = rangeOfVertices.map { TSNode(index: $0, color: .white) }
         var notDAG = false
+
+        // Determine vertex neighbors in advance, so we have to do it once for each node.
+        var neighbors: [Set<Int>] = rangeOfVertices.map({ index in
+            Set(edges[index].map({ $0.v }))
+        })
         
-        func visit(_ node: TSNode<V>) {
+        func visit(_ node: TSNode) {
             guard node.color != .gray else {
                 notDAG = true
                 return
             }
             if node.color == .white {
                 node.color = .gray
-                for inode in tsNodes where (neighborsForVertex(node.vertex)?.contains(inode.vertex))! {
+                for inode in tsNodes where neighbors[node.index].contains(inode.index) {
                     visit(inode)
                 }
                 node.color = .black
-                sortedVertices.insert(node.vertex, at: 0)
+                sortedVertices.insert(vertices[node.index], at: 0)
             }
         }
         
@@ -71,12 +77,12 @@ public extension Graph {
 
 fileprivate enum TSColor { case black, gray, white }
 
-fileprivate class TSNode<V> {
-    fileprivate let vertex: V
+fileprivate class TSNode {
+    fileprivate let index: Int
     fileprivate var color: TSColor
-    
-    init(vertex: V, color: TSColor) {
-        self.vertex = vertex
+
+    init(index: Int, color: TSColor) {
+        self.index = index
         self.color = color
     }
 }


### PR DESCRIPTION
This change improves the performance of topological sort by removing the linear lookups of vertices. I think it was something like O(n^4) with calls to `indexOfVertex`. I also try to do fewer vertex allocations by using indices everywhere, although this is relatively minor in comparison.

I didn't test exhaustively, but in my use case with ~500 vertices and ~500 edges, sorting went from 12s to 20ms!