### PR TITLE
Make conformances to Codable conditional

### DIFF
--- a/Sources/SwiftGraph/Constructors.swift
+++ b/Sources/SwiftGraph/Constructors.swift
@@ -18,7 +18,7 @@
 
 /// A type used to construct an UnweightedGraph with vertices of type V that is isomorphic to a star graph.
 /// https://en.wikipedia.org/wiki/Star_(graph_theory)
-public enum StarGraph<V: Equatable & Codable> {
+public enum StarGraph<V: Equatable> {
 
     /// Constructs an undirected UnweightedGraph isomorphic to a star graph.
     ///
@@ -41,7 +41,7 @@ public enum StarGraph<V: Equatable & Codable> {
 
 /// A type used to construct UnweightedGraph with vertices of type V that is isomorphic to a complete graph.
 /// https://en.wikipedia.org/wiki/Complete_graph
-public enum CompleteGraph<V: Equatable & Codable> {
+public enum CompleteGraph<V: Equatable> {
 
     /// Constructs an undirected UnweightedGraph isomorphic to a complete graph.
     ///

--- a/Sources/SwiftGraph/Edge.swift
+++ b/Sources/SwiftGraph/Edge.swift
@@ -17,7 +17,7 @@
 //  limitations under the License.
 
 /// A protocol that all edges in a graph must conform to.
-public protocol Edge: CustomStringConvertible & Codable {
+public protocol Edge: CustomStringConvertible {
     /// The origin vertex of the edge
     var u: Int {get set}  //made modifiable for changing when removing vertices
     /// The destination vertex of the edge

--- a/Sources/SwiftGraph/Graph.swift
+++ b/Sources/SwiftGraph/Graph.swift
@@ -19,8 +19,8 @@
 /// The protocol for all graphs.
 /// You should generally use one of its two canonical class implementations,
 /// *UnweightedGraph* and *WeightedGraph*
-public protocol Graph: CustomStringConvertible, Collection, Codable {
-    associatedtype V: Equatable & Codable
+public protocol Graph: CustomStringConvertible, Collection {
+    associatedtype V: Equatable
     associatedtype E: Edge & Equatable
     var vertices: [V] { get set }
     var edges: [[E]] { get set }

--- a/Sources/SwiftGraph/UnweightedEdge.swift
+++ b/Sources/SwiftGraph/UnweightedEdge.swift
@@ -17,7 +17,7 @@
 //  limitations under the License.
 
 /// A basic unweighted edge.
-public struct UnweightedEdge: Edge, CustomStringConvertible, Equatable {
+public struct UnweightedEdge: Edge, CustomStringConvertible, Equatable, Codable {
     public var u: Int
     public var v: Int
     public var directed: Bool

--- a/Sources/SwiftGraph/WeightedEdge.swift
+++ b/Sources/SwiftGraph/WeightedEdge.swift
@@ -29,7 +29,7 @@ extension WeightedEdge: WeightedEdgeProtocol {
 }
 
 /// A weighted edge, who's weight subscribes to Comparable.
-public struct WeightedEdge<W: Equatable & Codable>: Edge, CustomStringConvertible, Equatable {
+public struct WeightedEdge<W: Equatable>: Edge, CustomStringConvertible, Equatable {
     public var u: Int
     public var v: Int
     public var directed: Bool
@@ -62,4 +62,10 @@ extension WeightedEdge: Comparable where W: Comparable {
     static public func < (lhs: WeightedEdge, rhs: WeightedEdge) -> Bool {
         return lhs.weight < rhs.weight
     }
+}
+
+extension WeightedEdge: Decodable where W: Decodable {
+}
+
+extension WeightedEdge: Encodable where W: Encodable {
 }


### PR DESCRIPTION
I've ran into a problem when using the graph types with types that don't conform to Codable. Previously, if you used WeightedGraph<V, W>, then V and W both must conform to Codable, which prohibits WeightedGraph from being used in the case where V and W don't conform to Codable.

This pull request makes the conformance to Encodable and Decodable conditional for UnweightedGraph, WeightedGraph, and UniqueElementsGraph.

The conformances should be the same as the generated code by the compiler when confirming to Codable.

There are breaking changes, namely that:
- UnweightedGraph, WeightedGraph, and UniqueElementsGraph have a required convenience initialiser for constructing a graph from a Decoder. This would mean that any subclasses would fail to compile.
- Graph and Edge no longer inherits Codable. This means that conforming types would need to also conform to Codable themselves to maintain compatibility.

Let me know what you think. I'm welcome to any feedback you have to offer. Thanks.